### PR TITLE
Add readiness probe

### DIFF
--- a/operator/charts/netchecks/templates/deployment.yaml
+++ b/operator/charts/netchecks/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: 1
             periodSeconds: 2
+            timeoutSeconds: 5
             failureThreshold: 10
             httpGet:
               path: /healthz

--- a/operator/charts/netchecks/templates/deployment.yaml
+++ b/operator/charts/netchecks/templates/deployment.yaml
@@ -46,6 +46,13 @@ spec:
             timeoutSeconds: 10
             successThreshold: 1
             failureThreshold: 10
+          readinessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 10
+            httpGet:
+              path: /healthz
+              port: http
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
           env:


### PR DESCRIPTION
PR adds a [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) to the `netcheck-operator` since it has a `service`.

I've chosen the default values and set the `failureThreshold` to 10—feel free to update them prior to merging. Definitions for the configured values are [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)