### PR TITLE
reduce image sizes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM python:3.11
+FROM python:3.11-slim
 LABEL org.opencontainers.image.source=https://github.com/netchecks/netchecks
 
 # Configure Poetry
-ENV POETRY_VERSION=1.4.1
-ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VENV=/opt/poetry-venv
-ENV POETRY_CACHE_DIR=/opt/.cache
+ENV POETRY_VERSION=1.4.1 \
+    POETRY_HOME=/opt/poetry \
+    POETRY_VENV=/opt/poetry-venv \
+    POETRY_CACHE_DIR=/opt/.cache
 
 # Install poetry separated from system interpreter
 RUN python3 -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools \
-    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION}
+    && $POETRY_VENV/bin/pip install -U pip setuptools --no-cache-dir \
+    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
 
 # Add `poetry` to PATH
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
@@ -19,7 +19,7 @@ WORKDIR /app
 
 # Install dependencies
 COPY poetry.lock* pyproject.toml ./
-RUN poetry install --no-root
+RUN poetry install --no-root --no-cache
 
 COPY . /app
 RUN poetry install

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,16 +1,16 @@
-FROM python:3.11
+FROM python:3.11-slim
 LABEL org.opencontainers.image.source=https://github.com/netchecks/operator
 
 # Configure Poetry
-ENV POETRY_VERSION=1.4.1
-ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VENV=/opt/poetry-venv
-ENV POETRY_CACHE_DIR=/opt/.cache
+ENV POETRY_VERSION=1.4.1 \
+    POETRY_HOME=/opt/poetry \
+    POETRY_VENV=/opt/poetry-venv \
+    POETRY_CACHE_DIR=/opt/.cache
 
 # Install poetry separated from system interpreter
 RUN python3 -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools \
-    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION}
+    && $POETRY_VENV/bin/pip install -U pip setuptools --no-cache-dir \
+    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
 
 # Add `poetry` to PATH
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
@@ -19,8 +19,8 @@ WORKDIR /app
 
 # Install dependencies
 COPY poetry.lock* pyproject.toml ./
-RUN poetry install --no-root
+RUN poetry install --no-root --no-cache
 
 COPY . /app
-RUN poetry install
+RUN poetry install --no-cache
 CMD ["poetry", "run", "kopf", "run", "/app/netchecks_operator/main.py", "--liveness=http://0.0.0.0:8080/healthz"]


### PR DESCRIPTION
I noticed when building the images they were large! 

This PR reduces the image size, in order of impact:

* Uses the `slim` python based image. The full image probably isn't needed, unless there's a good reason I'm missing
* Add `--no-cache-dir` for `pip install` 
* Add `--no-cache` for `poetry install`
* Squashes the multiple `ENV` layers  into one

Comparison between the images before and after the changes in PR. The image names with the `-new` suffix are the ones built off of this PR. Overall ~700MB reduction in size per image.

```shell
$ docker images | grep netchecks
netchecks-new                             latest    1089e0d9e992   45 minutes ago   307MB
netchecks-operator-new                    latest    d60b70b6c75b   45 minutes ago   275MB
netchecks-operator                        latest    877c1c82c3ed   50 minutes ago   1.06GB
netchecks                                 latest    74a4f68c8bda   59 minutes ago   1.1GB
```