### PR TITLE
update kubectl wait command to match the correct label

### DIFF
--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -44,7 +44,7 @@ kubectl apply -f https://github.com/hardbyte/netchecks/raw/main/operator/manifes
 Wait until the netchecks namespace is running a Deployment with a ready Pod:
 
 ```shell
-kubectl wait Deployment -n netchecks -l app=netcheck-operator --for condition=Available --timeout=90s
+kubectl wait Deployment -n netchecks -l app.kubernetes.io/instance=netchecks-operator --for condition=Available --timeout=90s
 ```
 
 ### Basic Usage


### PR DESCRIPTION
I noticed the `kubectl wait` command in the docs didn't work based on the label name. PR fixes it so that it works—tested against a cluster:

```shell
$ kubectl wait Deployment -n netchecks -l app.kubernetes.io/instance=netchecks-operator --for condition=Available --timeout=90s
deployment.apps/netchecks-operator condition met
deployment.apps/netchecks-operator-policy-reporter condition met
```