### PR TITLE
remove different kubectl apply

### DIFF
--- a/docs/src/pages/docs/http.md
+++ b/docs/src/pages/docs/http.md
@@ -43,12 +43,6 @@ spec:
         message: Http request to Kubernetes API should succeed.
 ```
 
-Apply the `NetworkAssertion` to your cluster:
-
-```shell
-kubectl apply -f https://raw.githubusercontent.com/hardbyte/netchecks/main/operator/examples/default-k8s/http.yaml
-```
-
 ## Policy Report
 
 After the `NetworkAssertion` has been applied, a `CronJob` will be created in the `defalt` namespace to run the test every 10 minutes. The `CronJob` will create a `Pod` that runs the test and then a `PolicyReport` resource with the same name as the `NetworkAssertion` will be created in the same namespace. An example `PolicyReport` created by Netchecks is shown below:


### PR DESCRIPTION
On https://docs.netchecks.io/docs/http

PR removes the reference to [this manifest](https://raw.githubusercontent.com/hardbyte/netchecks/main/operator/examples/default-k8s/http.yaml), for the following reasons: 

* The example manifest is different from the one presented right above the command in the docs, i.e., different name, includes a `service`, and is scheduled `@hourly` instead of every 10 minutes which the docs say. This would confuse readers as to what happened (it certainly confused me!)
* The `apply` command is only done here but not in other parts of the docs, so I think it's maybe left over?