### PR TITLE
add NetcheckAssertions test on CI

### DIFF
--- a/.github/workflows/manifests/should-fail.yaml
+++ b/.github/workflows/manifests/should-fail.yaml
@@ -1,0 +1,20 @@
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: http-k8s-api-should-fail-ci
+  namespace: default
+  annotations:
+    description: Assert pod can connect to k8s API
+spec:
+  template:
+    metadata:
+      labels:
+        optional-label: applied-to-test-pod
+  rules:
+    - name: kubernetes-version
+      type: http
+      url: https://kubernetes/devnull
+      verify-tls-cert: false
+      expected: pass
+      validate:
+        message: Http request to Kubernetes API should succeed.

--- a/.github/workflows/manifests/should-pass.yaml
+++ b/.github/workflows/manifests/should-pass.yaml
@@ -1,0 +1,20 @@
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: http-k8s-api-should-pass-ci
+  namespace: default
+  annotations:
+    description: Assert failure for pod can connect to k8s API
+spec:
+  template:
+    metadata:
+      labels:
+        optional-label: applied-to-test-pod
+  rules:
+    - name: kubernetes-version
+      type: http
+      url: https://kubernetes/version
+      verify-tls-cert: false
+      expected: pass
+      validate:
+        message: Http request to Kubernetes API should succeed.

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -188,11 +188,9 @@ jobs:
 #          # Run the connectivity test
 #          cilium connectivity test --test dns-only,to-cidr-1111
 
-      - name: Remove a Network Assertion
+      - name: Remove Network Assertions
         run: |
-          kubectl delete -f operator/examples/default-k8s/dns.yaml
-          kubectl delete -f .github/workflows/manifests/should-pass.yaml
-          kubectl delete -f .github/workflows/manifests/should-fail.yaml
+          kubectl delete networkassertions --all-namespaces --all
 
       - name: Uninstall Netchecks
         if: ${{ always() }}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -162,8 +162,8 @@ jobs:
       # Check if networkassertions passed and failed as expected
       - name: NetworkAssertions pass/fail check
         run: |
+          [ "$(kubectl get policyreports http-k8s-api-should-pass-ci -o jsonpath='{.summary.pass}')" == "1" ] || exit 1;
           [ "$(kubectl get policyreports http-k8s-api-should-fail-ci -o jsonpath='{.summary.fail}')" == "1" ] || exit 1;
-          [ "$(kubectl get policyreports http-k8s-api-should-pass-ci -o jsonpath='{.summary.fail}')" == "1" ] || exit 1;
 
       # Install Cilium with HostPort support for extended connectivity test.
       - name: Install Cilium

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -118,9 +118,8 @@ jobs:
           kubectl get crd -A
 
       - name: Wait for Netcheck Operator to be ready
-        run: |    
+        run: |
           kubectl wait -n netchecks --for=condition=Ready --all pod --timeout=5m
-
 
       # Handy for debugging
       #- name: Explain NetworkAssertion CRD
@@ -132,9 +131,11 @@ jobs:
       #  run: |
       #    kubectl describe -n netcheck deployment/netcheck-operator
 
-      - name: Create a Network Assertion
+      - name: Create Network Assertions
         run: |
           kubectl apply -f operator/examples/default-k8s/dns.yaml
+          kubectl apply -f .github/workflows/manifests/should-pass.yaml
+          kubectl apply -f .github/workflows/manifests/should-fail.yaml
 
       # Check we can get the assertion
       - name: Get NetcheckAssertions
@@ -157,6 +158,12 @@ jobs:
         if: ${{ always() }}
         run: |
           kubectl logs -n netchecks deployment/netchecks-operator
+
+      # Check if networkassertions passed and failed as expected
+      - name: NetworkAssertions pass/fail check
+        run: |
+          [ "$(kubectl get policyreports http-k8s-api-should-fail-ci -o jsonpath='{.summary.fail}')" == "1" ] || exit 1;
+          [ "$(kubectl get policyreports http-k8s-api-should-pass-ci -o jsonpath='{.summary.fail}')" == "1" ] || exit 1;
 
       # Install Cilium with HostPort support for extended connectivity test.
       - name: Install Cilium
@@ -184,6 +191,8 @@ jobs:
       - name: Remove a Network Assertion
         run: |
           kubectl delete -f operator/examples/default-k8s/dns.yaml
+          kubectl delete -f .github/workflows/manifests/should-pass.yaml
+          kubectl delete -f .github/workflows/manifests/should-fail.yaml
 
       - name: Uninstall Netchecks
         if: ${{ always() }}


### PR DESCRIPTION
PR adds `NetworkAssertions` tests on the CI, and tests both pass and fail cases