### PR TITLE
Docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
+<div align="center">
 
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/netcheck) [![Coverage Status](https://coveralls.io/repos/github/hardbyte/netcheck/badge.svg?branch=main)](https://coveralls.io/github/hardbyte/netcheck?branch=main) ![PyPI - Downloads](https://img.shields.io/pypi/dm/netcheck)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/netcheck)
+[![Coverage Status](https://coveralls.io/repos/github/hardbyte/netcheck/badge.svg?branch=main)](https://coveralls.io/github/hardbyte/netcheck?branch=main)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/netcheck)
+
+</div>
+
 
 # Netchecks 
 
@@ -233,7 +239,7 @@ out by GitHub actions.
 
 Install dev dependencies with Poetry:
 
-```
+```shell
 poetry install --with dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Netchecks
+
+<p align="center">
+  <img alt="Netchecks Logo" src=".github/logo.png" width="150" />
+</p>
+
 <div align="center">
 
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/netcheck)
@@ -5,13 +11,6 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/netcheck)
 
 </div>
-
-
-# Netchecks 
-
-<p align="center">
-  <img alt="Netchecks Logo" src=".github/logo.png" width="150" />
-</p>
 
 **Netchecks** is a set of tools for testing network conditions and asserting that they are as expected.
 

--- a/docs/src/pages/docs/architecture-guide.md
+++ b/docs/src/pages/docs/architecture-guide.md
@@ -7,12 +7,12 @@ Netchecks runs in Kubernetes as an [operator](https://kubernetes.io/docs/concept
 operator is implemented in Python using the [kopf](https://kopf.readthedocs.io/en/stable) framework.
 
 The netchecks operator:
-- listens for `NetworkAssertion` resources across the kubernetes cluster and creates `CronJobs` for each of them.
-- listens for _probe_ Pods created by the NetworkAssertion's CronJob and parses assertion results from the Pod logs. 
-- creates and updates PolicyReport resources for each NetworkAssertion in response to the assertion results.
+- Listens for `NetworkAssertion` resources across the kubernetes cluster and creates `CronJobs` for each of them.
+- Listens for _probe_ Pods created by the NetworkAssertion's CronJob and parses assertion results from the Pod logs.
+- Creates and updates `PolicyReport` resources for each NetworkAssertion in response to the assertion results.
 
-Each probe pod uses the `netcheck` docker image to run the tests that make up a particular network assertion.
-The `netcheck` image is based on the [python:3.11](https://hub.docker.com/_/python) image.
+Each probe pod uses the `netchecks` docker image to run the tests that make up a particular network assertion.
+The `netchecks` image is based on the [python:3.11-slim](https://hub.docker.com/_/python) image.
 
 [Kyverno's PolicyReporter](https://kyverno.github.io/policy-reporter/) is optionally installed alongside Netchecks to
 provide a convenient way to expose metrics, view the results, and generate notifications.

--- a/docs/src/pages/docs/how-to-contribute.md
+++ b/docs/src/pages/docs/how-to-contribute.md
@@ -20,7 +20,7 @@ The code is available under the [netchecks](https://github.com/hardbyte/netcheck
 
 ### Docs
 
-Ddocumentation is available in the folder [netchecks/docs](https://github.com/hardbyte/netchecks/tree/main/docs).
+Documentation is available in the folder [netchecks/docs](https://github.com/hardbyte/netchecks/tree/main/docs).
 
 
 ### Netcheck Probe

--- a/docs/src/pages/docs/how-to-contribute.md
+++ b/docs/src/pages/docs/how-to-contribute.md
@@ -14,22 +14,22 @@ the project, including:
 The place to start is GitHub. If you find a bug or have a feature request, please open an issue in the appropriate
 repository. If you want to contribute code, please open a pull request.
 
-## Code Repositories
+## Code Repository
 
-The code is split across repositories under the [netchecks](https://github.com/netchecks) organisation on Github. 
+The code is available under the [netchecks](https://github.com/hardbyte/netchecks/) Github repository.
 
 ### Docs
 
-The repository responsible for this documentation is [netchecks/docs](https://github.com/netchecks/docs).
+Ddocumentation is available in the folder [netchecks/docs](https://github.com/hardbyte/netchecks/tree/main/docs).
 
 
 ### Netcheck Probe
 
-The command line tool that runs the network probes is called `netcheck`. It is implemented in Python and is available 
-as a PyPi package. The source code is available in the [netchecks](https://github.com/netchecks/netchecks) repository
+The command line tool that runs the network probes is called `netcheck`. It is implemented in Python and is available
+as a PyPi package. The source code is available in the [netchecks](https://github.com/hardbyte/netchecks/) repository
 on GitHub.
 
 ### Netcheck Operator
 
 The netchecks operator is implemented in Python using the [kopf](https://kopf.readthedocs.io/en/stable) framework
-and is available in the [operator](https://github.com/netchecks/operator) repository on GitHub.
+and is available in the [operator](https://github.com/hardbyte/netchecks/tree/main/operator) folder on GitHub.

--- a/docs/src/pages/docs/http.md
+++ b/docs/src/pages/docs/http.md
@@ -45,7 +45,7 @@ spec:
 
 ## Policy Report
 
-After the `NetworkAssertion` has been applied, a `CronJob` will be created in the `defalt` namespace to run the test every 10 minutes. The `CronJob` will create a `Pod` that runs the test and then a `PolicyReport` resource with the same name as the `NetworkAssertion` will be created in the same namespace. An example `PolicyReport` created by Netchecks is shown below:
+After the `NetworkAssertion` has been applied, a `CronJob` will be created in the `default` namespace to run the test every 10 minutes. The `CronJob` will create a `Pod` that runs the test and then a `PolicyReport` resource with the same name as the `NetworkAssertion` will be created in the same namespace. An example `PolicyReport` created by Netchecks is shown below:
 
 ```yaml
 apiVersion: wgpolicyk8s.io/v1alpha2

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -21,7 +21,7 @@ The helm chart is not **yet** available in a public helm repository. To install 
 clone the git repo and run:
 
 ```shell
-helm upgrade --install netchecks-operator  operator/charts/netchecks/ -n netchecks --create-namespace
+helm upgrade --install netchecks-operator operator/charts/netchecks/ -n netchecks --create-namespace
 ```
 
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -93,7 +93,7 @@ The helm chart is not **yet** available in a public helm repository. To install 
 clone the git repo and run:
 
 ```shell
-helm upgrade --install netchecks-operator  charts/netchecks/ -n netchecks --create-namespace
+helm upgrade --install netchecks-operator charts/netchecks/ -n netchecks --create-namespace
 ```
 
 


### PR DESCRIPTION
General cleanup, general outline:

* [Center badges and move them below logo](https://github.com/hardbyte/netchecks/blob/25bccf241a6517fa69d287c5c75ad334dfd26e4b/README.md)
* Update links and references from old org to the new repo, deprecated naming and refs to the old base image
* Minor typos