### PR TITLE
explicitly copy what's needed for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 WORKDIR /app
 
 # Install dependencies
-COPY poetry.lock* pyproject.toml ./
+COPY poetry.lock* pyproject.toml README.md ./
 RUN poetry install --no-root --no-cache
 
-COPY . /app
+COPY ./netcheck/ /app/netcheck/
 RUN poetry install
 ENTRYPOINT ["poetry", "run", "netcheck"]
 CMD ["http", "-v"]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,9 +18,9 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 WORKDIR /app
 
 # Install dependencies
-COPY poetry.lock* pyproject.toml ./
+COPY poetry.lock* pyproject.toml README.md ./
 RUN poetry install --no-root --no-cache
 
-COPY . /app
+COPY ./netchecks_operator/ /app/netchecks_operator/
 RUN poetry install --no-cache
 CMD ["poetry", "run", "kopf", "run", "/app/netchecks_operator/main.py", "--liveness=http://0.0.0.0:8080/healthz"]


### PR DESCRIPTION
PR Removes wildcard `COPY .` since it adds unnecessary files and in the worst case could leak sensitive data. We could add a `.dockerignore`, but IMO it's much better to just explicitly declare what needs to copied in. Note that the `README.md` file needs to be copied in since the `pyproject.toml` files reference it (`poetry` fails otherwise)