### PR TITLE
add shellcheck and hadolint to CI + ensure they pass

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+
+on: [push]
+
+jobs:
+  check-linters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: reviewdog/action-shellcheck@v1
+        with:
+          filter_mode: file
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          recursive: true

--- a/operator/create-static-manifests.sh
+++ b/operator/create-static-manifests.sh
@@ -2,23 +2,21 @@
 # Generates the /manifests/deploy.yaml
 
 if [ -n "$DEBUG" ]; then
-	set -x
+  set -x
 fi
 
 #set -o errexit
 set -o nounset
 set -o pipefail
 
+cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P
 
-cd $(dirname "${BASH_SOURCE}") && pwd -P
-
-MANIFEST=manifests/deploy.yaml
+MANIFEST="manifests/deploy.yaml"
 
 helm template netchecks-operator ./charts/netchecks \
   --values examples/kind-installation/values.yaml \
   --namespace netchecks \
-  > $MANIFEST
+  > "${MANIFEST}"
 
-sed -i.bak '/app.kubernetes.io\/managed-by: Helm/d' $MANIFEST
-sed -i.bak '/helm.sh/d' $MANIFEST
-
+sed -i.bak '/app.kubernetes.io\/managed-by: Helm/d' "${MANIFEST}"
+sed -i.bak '/helm.sh/d' "${MANIFEST}"


### PR DESCRIPTION
PR adds [shellcheck](https://www.shellcheck.net/) and [hadolint](https://github.com/hadolint/hadolint), and updates the shellscript so it passes CI. The Dockerfiles already pass `hadolint`