### PR TITLE
run container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,23 @@ FROM python:3.11-slim
 LABEL org.opencontainers.image.source=https://github.com/netchecks/netchecks
 
 # Configure Poetry
-ENV POETRY_VERSION=1.4.1 \
-    POETRY_HOME=/opt/poetry \
-    POETRY_VENV=/opt/poetry-venv \
-    POETRY_CACHE_DIR=/opt/.cache
+ENV USERNAME=netchecks \
+    USER_UID=1000 \
+    USER_GID=1000 \
+    POETRY_VERSION=1.4.1 \
+    POETRY_HOME=/home/netchecks/bin/poetry \
+    POETRY_VENV=/home/netchecks/bin/poetry-venv \
+    POETRY_CACHE_DIR=/home/netchecks/bin/.cache
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+
+USER ${USERNAME}
 
 # Install poetry separated from system interpreter
-RUN python3 -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools --no-cache-dir \
-    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
+RUN python3 -m venv ${POETRY_VENV} \
+    && ${POETRY_VENV}/bin/pip install -U pip setuptools --no-cache-dir \
+    && ${POETRY_VENV}/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
 
 # Add `poetry` to PATH
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
@@ -18,10 +26,10 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 WORKDIR /app
 
 # Install dependencies
-COPY poetry.lock* pyproject.toml README.md ./
+COPY --chown=${USERNAME}:${USER_GID} poetry.lock* pyproject.toml README.md ./
 RUN poetry install --no-root --no-cache
 
-COPY ./netcheck/ /app/netcheck/
-RUN poetry install
+COPY --chown=${USERNAME}:${USER_GID} ./netcheck/ /app/netcheck/
+RUN poetry install --no-cache
 ENTRYPOINT ["poetry", "run", "netcheck"]
 CMD ["http", "-v"]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,15 +2,23 @@ FROM python:3.11-slim
 LABEL org.opencontainers.image.source=https://github.com/netchecks/operator
 
 # Configure Poetry
-ENV POETRY_VERSION=1.4.1 \
-    POETRY_HOME=/opt/poetry \
-    POETRY_VENV=/opt/poetry-venv \
-    POETRY_CACHE_DIR=/opt/.cache
+ENV USERNAME=netchecks \
+    USER_UID=1000 \
+    USER_GID=1000 \
+    POETRY_VERSION=1.4.1 \
+    POETRY_HOME=/home/netchecks/bin/poetry \
+    POETRY_VENV=/home/netchecks/bin/poetry-venv \
+    POETRY_CACHE_DIR=/home/netchecks/bin/.cache
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+
+USER ${USERNAME}
 
 # Install poetry separated from system interpreter
-RUN python3 -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools --no-cache-dir \
-    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
+RUN python3 -m venv ${POETRY_VENV} \
+    && ${POETRY_VENV}/bin/pip install -U pip setuptools --no-cache-dir \
+    && ${POETRY_VENV}/bin/pip install poetry==${POETRY_VERSION} --no-cache-dir
 
 # Add `poetry` to PATH
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
@@ -18,9 +26,9 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 WORKDIR /app
 
 # Install dependencies
-COPY poetry.lock* pyproject.toml README.md ./
+COPY --chown=${USERNAME}:${USER_GID} poetry.lock* pyproject.toml README.md ./
 RUN poetry install --no-root --no-cache
 
-COPY ./netchecks_operator/ /app/netchecks_operator/
+COPY --chown=${USERNAME}:${USER_GID} ./netchecks_operator/ /app/netchecks_operator/
 RUN poetry install --no-cache
 CMD ["poetry", "run", "kopf", "run", "/app/netchecks_operator/main.py", "--liveness=http://0.0.0.0:8080/healthz"]


### PR DESCRIPTION
PR:

* Sets user and group IDs as `1000`, user is called `netchecks`
* Installs poetry in `~/bin/`, since `/opt/` isn't writable to non-root users
* Added missing `--no-cache` to the cli Dockerfile—should be even smaller now!