### PR TITLE
:memo: cleanup docs

### DIFF
--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -44,7 +44,6 @@ const navigation = [
             {title: 'How to contribute', href: '/docs/how-to-contribute'},
             {title: 'Development', href: '/docs/development',},
             {title: 'Architecture guide', href: '/docs/architecture-guide'},
-            {title: 'Kubernetes Operator', href: '/docs/operator'},
             {title: 'Testing', href: '/docs/testing'},
             {title: 'Design principles', href: '/docs/design-principles'},
             {title: 'Release Guide', href: '/docs/releasing'},

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,13 +1,14 @@
+# Netchecks Operator
+
 The **Netchecks Operator** provides a cloud native way to dynamically declare a set of statements about 
 the network (what should work and what shouldn't).
 
 
 ## High Level Diagram
 
-![High Level Diagram](doc/High-Level-Diagram.png)
+![Netchecks Operator High Level Diagram](doc/High-Level-Diagram.png)
 
 ## Example
-
 
 
 ```yaml
@@ -77,6 +78,8 @@ summary:
   pass: 1
 ```
 
+For more examples see the [examples folder](examples/)
+
 
 ## Installation
 
@@ -114,7 +117,8 @@ Then apply your `NetworkAssertions` as any other resource.
 You will need to install [cosign](https://docs.sigstore.dev/cosign/installation/).
 
 Verify Signed Container Images
-```
+
+```shell
 $ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository netchecks/operator --certificate-oidc-issuer https://token.actions.githubusercontent.com ghcr.io/netchecks/operator:main | jq
 ```
 
@@ -124,7 +128,9 @@ $ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository n
 
 To verify that an image was created for a specific release add the following to the cosign command:
 
+```shell
 --certificate-github-workflow-ref refs/tags/[RELEASE TAG] ghcr.io/netchecks/operator:[VERSION] | jq
+```
 
 ## Development
 


### PR DESCRIPTION
PR

* Adds a link to the the `example` folder for the oeprator
* Removes the `/docs/operator` href which 404s