### PR TITLE
build multi-platform docker images

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -157,6 +157,8 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push
@@ -165,6 +167,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 #      - name: Install Cosign

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -54,6 +54,8 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push
@@ -61,6 +63,7 @@ jobs:
         with:
           context: operator
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 #      - name: Install Cosign


### PR DESCRIPTION
PR adds building and pushing [multi-platform](https://docs.docker.com/build/building/multi-platform/) images. Note that `QEMU` is used, so building _will_ be slower.

I added `linux/arm64`. This will allow users to run the operator on ARM nodes, and for people with Apple Silicon machines to easily test it locally.

Here's the list of available platforms btw

``` 
linux/amd64
linux/arm64
linux/riscv64
linux/ppc64le
linux/s390x
linux/386
linux/mips64le
linux/mips64
linux/arm/v7
linux/arm/v6
```