### PR TITLE
Improve cli ergonomics

### DIFF
--- a/netcheck/cli.py
+++ b/netcheck/cli.py
@@ -76,7 +76,6 @@ def run(
 def http(
         url: str = typer.Option('https://github.com/status', help="URL to request", rich_help_panel="http test"),
         method: NetcheckHttpMethod = typer.Option(NetcheckHttpMethod.get,
-                                                  "--method",
                                                   help="HTTP method",
                                                   rich_help_panel='http test',
                                                   case_sensitive=False),

--- a/netcheck/cli.py
+++ b/netcheck/cli.py
@@ -16,7 +16,7 @@ from .runner import run_from_config, check_individual_assertion
 
 
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 logger = logging.getLogger("netcheck")
 #logging.basicConfig(level=logging.INFO)
 logging.captureWarnings(True)
@@ -48,13 +48,13 @@ def common(
 
 @app.command()
 def run(
-        config: Path = typer.Option(..., exists=True, file_okay=True,
+        config: Path = typer.Option(..., "--config", "-c", exists=True, file_okay=True,
                                     help='Config file with netcheck assertions'),
         output: Optional[NetcheckOutputType] = typer.Option(NetcheckOutputType.json,
                                                             '-o',
                                                             '--output',
                                                             help="Output format"),
-        verbose: bool = typer.Option(False, '-v')
+        verbose: bool = typer.Option(False, '-v', '--verbose')
         ):
     """Carry out all network assertions in given config file.
     """
@@ -76,8 +76,10 @@ def run(
 def http(
         url: str = typer.Option('https://github.com/status', help="URL to request", rich_help_panel="http test"),
         method: NetcheckHttpMethod = typer.Option(NetcheckHttpMethod.get,
+                                                  "--method",
                                                   help="HTTP method",
-                                                  rich_help_panel='http test'),
+                                                  rich_help_panel='http test',
+                                                  case_sensitive=False),
         timeout: float = typer.Option(30.0, '-t', '--timeout', help='Timeout in seconds'),
         should_fail: bool = typer.Option(False, "--should-fail/--should-pass"),
         validation_rule: str = typer.Option(None, "--validation-rule", help="Validation rule in CEL to apply to result"),
@@ -130,7 +132,7 @@ def output_result(result, should_fail, verbose):
 
 @app.command()
 def dns(
-        server: str = typer.Option(None, help="DNS server to use for dns tests.", rich_help_panel="dns test"),
+        server: str = typer.Option(None, "--server", "-s", help="DNS server to use for dns tests.", rich_help_panel="dns test"),
         host: str = typer.Option('github.com', help='Host to search for', rich_help_panel="dns test"),
         should_fail: bool = typer.Option(False, "--should-fail/--should-pass"),
         validation_rule: str = typer.Option(None, "--validation-rule", help="Validation rule in CEL to apply to result"),

--- a/netcheck/runner.py
+++ b/netcheck/runner.py
@@ -63,7 +63,7 @@ def check_individual_assertion(test_type: str, test_config, err_console, validat
                 err_console.print(f"http check with url '{test_config['url']}'")
             test_detail = http_request_check(
                 test_config['url'],
-                test_config.get('method', 'get'),
+                test_config.get('method', 'get').lower(),
                 headers=test_config.get('headers'),
                 timeout=test_config.get('timeout'),
                 verify=test_config.get('verify-tls-cert', True),


### PR DESCRIPTION
PR attempts to improve some usability issues I found when trying it out

* Adds `no_args_is_help` ([it's not documented](https://github.com/tiangolo/typer/blob/50caff27573e0d1381701d24122ca9fed20d6343/typer/models.py#L102) but should be), so if nothing is passed it'll show `--help` instead of `Missing command`
* Adds extra short flags
  *  `-c` for config
  * `-s` for server
  * I wanted to add more, but `-h` wouldn't work for host, and `--method`, for _me_ at least is `-X` but that's a matter of opinion—so I left these out.
* I noticed the `method` were case sensitive, i.e., it expected lowercase `get`, `post` etc. — now either case is allowed in both the CLI and config files—since most people are used to typing methods in uppercase