### PR TITLE
make 💪 work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,13 +267,12 @@ jobs:
         run: |
           cd operator
           poetry install --no-interaction --with dev
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Load netchecks image
+      - name: Pull netchecks probe image
+        run: |
+          docker pull ${{ needs.probe_docker.outputs.image_probe }}
+      - name: Pull netchecks operator image
         run: |
           docker pull ${{ needs.operator_docker.outputs.image_operator }}
-          docker pull ${{ needs.probe_docker.outputs.image_probe }}
-          docker image ls -a
       - name: Install kubectl
         run: |
           curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
     name: Build Probe Image
     runs-on: ubuntu-latest
     outputs:
-      image_probe_: ${{ steps.meta_probe.outputs.tags }}
+      image_probe: ${{ steps.meta_probe.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -267,11 +267,9 @@ jobs:
         run: |
           cd operator
           poetry install --no-interaction --with dev
-      - name: Pull netchecks probe image
+      - name: Pull netchecks images
         run: |
           docker pull ${{ needs.probe_docker.outputs.image_probe }}
-      - name: Pull netchecks operator image
-        run: |
           docker pull ${{ needs.operator_docker.outputs.image_operator }}
       - name: Install kubectl
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,7 +174,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Export Docker Image
         run: |
-          docker save ghcr.io/hardbyte/netchecks:edge -o /tmp/netchecks_probe_image.tar
+          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker save ghcr.io/hardbyte/netchecks:edge -o /tmp/netchecks_probe_image.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -227,7 +227,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Export Docker Image
         run: |
-          docker save ghcr.io/hardbyte/netchecks-operator:edge -o /tmp/netchecks_operator_image.tar
+          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker save ghcr.io/hardbyte/netchecks-operator:edge -o /tmp/netchecks_operator_image.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
     name: Build Probe Image
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.meta.outputs.tags }}
+      image_probe_: ${{ steps.meta_probe.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -145,7 +145,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Docker meta
-        id: meta
+        id: meta_probe
         uses: docker/metadata-action@v4
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
@@ -179,7 +179,7 @@ jobs:
     name: Build Operator Image
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.meta.outputs.tags }}
+      image_operator: ${{ steps.meta_operator.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -193,7 +193,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Docker meta
-        id: meta
+        id: meta_operator
         uses: docker/metadata-action@v4
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
@@ -271,8 +271,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Load netchecks image
         run: |
-          docker pull ${{ needs.operator_docker.outputs.image }}
-          docker pull ${{ needs.probe_docker.outputs.image }}
+          docker pull ${{ needs.operator_docker.outputs.image_operator }}
+          docker pull ${{ needs.probe_docker.outputs.image_probe }}
           docker image ls -a
       - name: Install kubectl
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,10 +267,6 @@ jobs:
         run: |
           cd operator
           poetry install --no-interaction --with dev
-      - name: Pull netchecks images
-        run: |
-          docker pull ${{ needs.probe_docker.outputs.image_probe }}
-          docker pull ${{ needs.operator_docker.outputs.image_operator }}
       - name: Install kubectl
         run: |
           curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
@@ -298,8 +294,10 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          kind load docker-image ${{ needs.operator_docker.outputs.image }}
-          kind load docker-image ${{ needs.probe_docker.outputs.image }}
+          docker pull --platform linux/amd64 ${{ needs.probe_docker.outputs.image_probe }}
+          docker pull --platform linux/amd64 ${{ needs.operator_docker.outputs.image_operator }}
+          kind load docker-image ${{ needs.probe_docker.outputs.image_probe }}
+          kind load docker-image ${{ needs.operator_docker.outputs.image_operator }}
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,7 +217,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: operator
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,8 @@ jobs:
   probe_docker:
     name: Build Probe Image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -168,22 +170,24 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Export Docker Image
-        run: |
-          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker save ghcr.io/hardbyte/netchecks:edge -o /tmp/netchecks_probe_image.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: netchecks_probe_image
-          path: /tmp/netchecks_probe_image.tar
+            #      - name: Export Docker Image
+            #        run: |
+            #          docker save ghcr.io/hardbyte/netchecks:edge -o /tmp/netchecks_probe_image.tar
+            #      - name: Upload artifact
+            #        uses: actions/upload-artifact@v3
+            #        with:
+            #          name: netchecks_probe_image
+            #          path: /tmp/netchecks_probe_image.tar
 
   operator_docker:
     name: Build Operator Image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -225,14 +229,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Export Docker Image
-        run: |
-          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker save ghcr.io/hardbyte/netchecks-operator:edge -o /tmp/netchecks_operator_image.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: netchecks_operator_image
-          path: /tmp/netchecks_operator_image.tar
+            #      - name: Export Docker Image
+            #        run: |
+            #          docker save ghcr.io/hardbyte/netchecks-operator:edge -o /tmp/netchecks_operator_image.tar
+            #      - name: Upload artifact
+            #        uses: actions/upload-artifact@v3
+            #        with:
+            #          name: netchecks_operator_image
+            #          path: /tmp/netchecks_operator_image.tar
 
   #      - name: Install Cosign
 #        uses: sigstore/cosign-installer@main
@@ -294,8 +298,8 @@ jobs:
           path: /tmp
       - name: Load netchecks image
         run: |
-          docker load --input /tmp/netchecks_operator_image.tar
-          docker load --input /tmp/netchecks_probe_image.tar
+          docker pull ${{ needs.operator_docker.outputs.image }}
+          docker pull ${{ needs.probe_docker.outputs.image }}
           docker image ls -a
       - name: Install kubectl
         run: |
@@ -304,7 +308,6 @@ jobs:
           echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
           kubectl version --client
-
       - name: Install cilium CLI binary
         run: |
           curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
@@ -322,7 +325,7 @@ jobs:
           kubectl cluster-info
           export KUBE_API=$(kubectl config view -o jsonpath='{.clusters[0].cluster.server}')
           kind get nodes
-          
+
       - name: Load Netchecks Images into Kind
         run: |
           kind load docker-image ghcr.io/hardbyte/netchecks:edge

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,10 +294,10 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          docker pull --platform linux/amd64 ${{ needs.probe_docker.outputs.image_probe }}
-          docker pull --platform linux/amd64 ${{ needs.operator_docker.outputs.image_operator }}
-          kind load docker-image ${{ needs.probe_docker.outputs.image_probe }}
-          kind load docker-image ${{ needs.operator_docker.outputs.image_operator }}
+          docker pull --platform linux/amd64 ${{ needs.probe_docker.outputs.image_probe[1] }}
+          docker pull --platform linux/amd64 ${{ needs.operator_docker.outputs.image_operator[1] }}
+          kind load docker-image ${{ needs.probe_docker.outputs.image_probe[1] }}
+          kind load docker-image ${{ needs.operator_docker.outputs.image_operator[1] }}
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,10 +294,10 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:${{ github.sha }}
-          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:${{ github.sha }}
-          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:${{ github.sha }}
-          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:${{ github.sha }}
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:sha-${GITHUB_SHA::7}
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:sha-${GITHUB_SHA::7}
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:sha-${GITHUB_SHA::7}
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:sha-${GITHUB_SHA::7}
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,14 +174,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-            #      - name: Export Docker Image
-            #        run: |
-            #          docker save ghcr.io/hardbyte/netchecks:edge -o /tmp/netchecks_probe_image.tar
-            #      - name: Upload artifact
-            #        uses: actions/upload-artifact@v3
-            #        with:
-            #          name: netchecks_probe_image
-            #          path: /tmp/netchecks_probe_image.tar
 
   operator_docker:
     name: Build Operator Image
@@ -229,22 +221,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-            #      - name: Export Docker Image
-            #        run: |
-            #          docker save ghcr.io/hardbyte/netchecks-operator:edge -o /tmp/netchecks_operator_image.tar
-            #      - name: Upload artifact
-            #        uses: actions/upload-artifact@v3
-            #        with:
-            #          name: netchecks_operator_image
-            #          path: /tmp/netchecks_operator_image.tar
-
-  #      - name: Install Cosign
-#        uses: sigstore/cosign-installer@main
-#      - name: Sign the images with GitHub OIDC Token
-#        run: cosign sign --yes ${TAGS}
-#        if: github.event_name != 'pull_request'
-#        env:
-#          TAGS: ${{ steps.meta.outputs.tags }}
+            #      - name: Install Cosign
+            #        uses: sigstore/cosign-installer@main
+            #      - name: Sign the images with GitHub OIDC Token
+            #        run: cosign sign --yes ${TAGS}
+            #        if: github.event_name != 'pull_request'
+            #        env:
+            #          TAGS: ${{ steps.meta.outputs.tags }}
 
 
   k8s:
@@ -286,16 +269,6 @@ jobs:
           poetry install --no-interaction --with dev
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-          #      - name: Download probe image artifact
-          #        uses: actions/download-artifact@v3
-          #        with:
-          #          name: netchecks_probe_image
-          #          path: /tmp
-          #      - name: Download operator image artifact
-          #        uses: actions/download-artifact@v3
-          #        with:
-          #          name: netchecks_operator_image
-          #          path: /tmp
       - name: Load netchecks image
         run: |
           docker pull ${{ needs.operator_docker.outputs.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          load: true
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -222,7 +221,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: operator
-          load: true
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           context: .
           load: true
           push: ${{ github.event_name != 'pull_request' }}
-          #platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Export Docker Image
@@ -224,8 +224,7 @@ jobs:
           context: operator
           load: true
           push: ${{ github.event_name != 'pull_request' }}
-          # See https://github.com/cdalvaro/docker-salt-master/blob/c556e06e5527cc2dc95966039858671f5f16cebe/.github/workflows/build-and-test.yml
-          #platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Export Docker Image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
           tags: |
-            edge
+            type=sha
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -194,7 +194,7 @@ jobs:
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
           tags: |
-            edge
+            type=sha
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -294,10 +294,10 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:edge
-          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:edge
-          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:edge
-          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:edge
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:${{ github.sha }}
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:${{ github.sha }}
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:${{ github.sha }}
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:${{ github.sha }}
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,8 +130,6 @@ jobs:
   probe_docker:
     name: Build Probe Image
     runs-on: ubuntu-latest
-    outputs:
-      image_probe: ${{ steps.meta_probe.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -145,7 +143,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Docker meta
-        id: meta_probe
+        id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
@@ -172,14 +170,12 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_probe.outputs.tags }}
-          labels: ${{ steps.meta_probe.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   operator_docker:
     name: Build Operator Image
     runs-on: ubuntu-latest
-    outputs:
-      image_operator: ${{ steps.meta_operator.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -193,7 +189,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Docker meta
-        id: meta_operator
+        id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
@@ -219,8 +215,8 @@ jobs:
           context: operator
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_operator.outputs.tags }}
-          labels: ${{ steps.meta_operator.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
             #      - name: Install Cosign
             #        uses: sigstore/cosign-installer@main
             #      - name: Sign the images with GitHub OIDC Token
@@ -243,6 +239,10 @@ jobs:
       cilium_version: v1.13.2
       cilium_cli_version: v0.13.2
       kubectl_version: v1.25.2
+      PROBE_IMAGE_NAME: netchecks
+      OPERATOR_IMAGE_NAME: netchecks-operator
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: hardbyte
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -294,10 +294,10 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          docker pull --platform linux/amd64 ${{ needs.probe_docker.outputs.image_probe[1] }}
-          docker pull --platform linux/amd64 ${{ needs.operator_docker.outputs.image_operator[1] }}
-          kind load docker-image ${{ needs.probe_docker.outputs.image_probe[1] }}
-          kind load docker-image ${{ needs.operator_docker.outputs.image_operator[1] }}
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:edge
+          docker pull ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:edge
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.PROBE_IMAGE_NAME}}:edge
+          kind load docker-image ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.OPERATOR_IMAGE_NAME}}:edge
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,8 +172,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_probe.outputs.tags }}
+          labels: ${{ steps.meta_probe.outputs.labels }}
 
   operator_docker:
     name: Build Operator Image
@@ -219,8 +219,8 @@ jobs:
           context: operator
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_operator.outputs.tags }}
+          labels: ${{ steps.meta_operator.outputs.labels }}
             #      - name: Install Cosign
             #        uses: sigstore/cosign-installer@main
             #      - name: Sign the images with GitHub OIDC Token

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,16 +286,16 @@ jobs:
           poetry install --no-interaction --with dev
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Download probe image artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: netchecks_probe_image
-          path: /tmp
-      - name: Download operator image artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: netchecks_operator_image
-          path: /tmp
+          #      - name: Download probe image artifact
+          #        uses: actions/download-artifact@v3
+          #        with:
+          #          name: netchecks_probe_image
+          #          path: /tmp
+          #      - name: Download operator image artifact
+          #        uses: actions/download-artifact@v3
+          #        with:
+          #          name: netchecks_operator_image
+          #          path: /tmp
       - name: Load netchecks image
         run: |
           docker pull ${{ needs.operator_docker.outputs.image }}
@@ -328,8 +328,8 @@ jobs:
 
       - name: Load Netchecks Images into Kind
         run: |
-          kind load docker-image ghcr.io/hardbyte/netchecks:edge
-          kind load docker-image ghcr.io/hardbyte/netchecks-operator:edge
+          kind load docker-image ${{ needs.operator_docker.outputs.image }}
+          kind load docker-image ${{ needs.probe_docker.outputs.image }}
       - name: Prepare Netchecks Operator Helm Chart
         run: |
           helm dependency build operator/charts/netchecks


### PR DESCRIPTION
PR re-adds support for multi-arch images. Uses docker push + pull between jobs rather than the `docker save` w/ artifacts approach which doesn't seem ideal.

It'll also be an implicit test of a multi-arch docker pull