### PR TITLE
🔐 Allow limiting which  ConfigMap/Secret items get projected

### DIFF
--- a/docs/src/pages/docs/external-data.md
+++ b/docs/src/pages/docs/external-data.md
@@ -9,10 +9,8 @@ When an assertion referencing a ConfigMap or Secret is evaluated, the data is mo
 Pod carrying out the assertion at the time the test runs. Should the Secret or ConfigMap be
 updated, subsequent probes will pick up the latest data at that point.
 
-This data is made available to the probe in the form of a context.
-
-In order to reference external data in NetworkAssertion rules, a context is required. The context 
-data can then be referenced within a CEL template.
+This data is made available to the probe in the form of a context. The context data can then be
+referenced within a CEL template.
 
 ```
 {{ <context-name>.<key-name> }}
@@ -187,6 +185,9 @@ spec:
 
 Data to be used in multiple rules can be declared as an **inline context**, and 
 can reference already defined contexts using the `{{ }}` template syntax. 
+
+This can be useful to pre-process external data in one place that 
+might be reused in multiple NetworkAssertion rules.
 
 For example:
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -147,7 +147,7 @@ poetry run kopf run netchecks_operator/main.py --liveness=http://0.0.0.0:8080/he
 ### Building and loading a local probe Docker container
 
 ```shell
-kind load docker-image ghcr.io/hardbyte/netchecks:local
+kind load docker-image ghcr.io/hardbyte/netchecks:main
 ```
 
 ### Create a NetworkAssertion

--- a/operator/netchecks_operator/main.py
+++ b/operator/netchecks_operator/main.py
@@ -602,6 +602,7 @@ def create_job_spec(
             volumes.append(
                 V1Volume(
                     name=context_name,
+                    # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1ConfigMapVolumeSource.md
                     config_map=V1ConfigMapVolumeSource(
                         **context_definition["configMap"]
                     ),

--- a/operator/tests/testdata/with-secret-data.yaml
+++ b/operator/tests/testdata/with-secret-data.yaml
@@ -4,6 +4,7 @@ metadata:
   name: some-secret
 data:
   API_TOKEN: a3E0Z2lodnN6emduMXAwcg==
+  UNWANTED: aGlkZGVu
 ---
 apiVersion: netchecks.io/v1
 kind: NetworkAssertion
@@ -16,6 +17,9 @@ spec:
     - name: somecontext
       secret:
         name: some-secret
+        items:
+          - key: API_TOKEN
+            path: API_TOKEN
   rules:
     - name: pie-dev-headers-and-validation
       type: http


### PR DESCRIPTION
Close out #33 by documenting how to limit which items get projected from a ConfigMap or Secret.