### PR TITLE
⚡️add PYTHONUNBUFFERED + PYTHONDONTWRITEBYTECODE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ ENV USERNAME=netchecks \
     POETRY_VERSION=1.4.1 \
     POETRY_HOME=/home/netchecks/bin/poetry \
     POETRY_VENV=/home/netchecks/bin/poetry-venv \
-    POETRY_CACHE_DIR=/home/netchecks/bin/.cache
+    POETRY_CACHE_DIR=/home/netchecks/bin/.cache \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 RUN groupadd --gid ${USER_GID} ${USERNAME} \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -8,7 +8,9 @@ ENV USERNAME=netchecks \
     POETRY_VERSION=1.4.1 \
     POETRY_HOME=/home/netchecks/bin/poetry \
     POETRY_VENV=/home/netchecks/bin/poetry-venv \
-    POETRY_CACHE_DIR=/home/netchecks/bin/.cache
+    POETRY_CACHE_DIR=/home/netchecks/bin/.cache \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 RUN groupadd --gid ${USER_GID} ${USERNAME} \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}

--- a/operator/netchecks_operator/config.py
+++ b/operator/netchecks_operator/config.py
@@ -45,7 +45,9 @@ class ProbeConfig(BaseModel):
     podAnnotations: dict[str, str] = {}
     image: ImageConfig = ImageConfig()
     resources: dict[str, dict] = {}
-    verbose: bool = False  # Don't enable until the operator has been modified to split stdout and stderr
+    verbose: bool = (
+        False  # Don't enable until the operator has been modified to split stdout and stderr
+    )
 
 
 class Config(BaseSettings):


### PR DESCRIPTION
PR

- Adds `PYTHONUNBUFFERED`  which forces the stdout + stderr streams to be unbuffered. This option has no effect on the stdin stream, and is useful for containers since we're collecting logs in realtime via stdout/stderr
- Adds `PYTHONDONTWRITEBYTECODE` which disables writing bytecode, i.e., `.pyc` files, since they're not needed for single-process docker containers and it'll reduce the docker image size
- `black` fmt, looks like there's a new stable version

