### PR TITLE
pin to macos-13 until arm64 is fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest]
+        os: [ ubuntu-latest, windows-latest, macOS-13]
         python: [ "3.10", "3.11"]
       fail-fast: true
     env:


### PR DESCRIPTION
PR to pin to `macos-13` since `macos-latest` now defaults to arm64 and there is a mismatch in expected architecture when running the unit test, as seen in https://github.com/hardbyte/netchecks/actions/runs/8819242277/job/24211182336#step:7:43