### PR TITLE
Consolidate marketing site into docs at netchecks.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/netcheck?style=flat-square&logo=python)
 [![Coverage Status](https://img.shields.io/coverallsCoverage/github/hardbyte/netchecks?branch=main&style=flat-square&logo=coveralls)](https://coveralls.io/github/hardbyte/netcheck?branch=main)
 [![CI status](https://img.shields.io/github/actions/workflow/status/hardbyte/netchecks/ci.yaml?branch=main&style=flat-square&logo=github)](https://github.com/hardbyte/netchecks/actions?query=branch%3Amain)
-[![Website](https://img.shields.io/website?url=https%3A%2F%2Fdocs.netchecks.io%2F&style=flat-square&label=docs.netchecks.io)](https://docs.netchecks.io/)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fnetchecks.io%2F&style=flat-square&label=netchecks.io)](https://netchecks.io/)
 [![Linting: ruff](https://img.shields.io/badge/linting-ruff-261230.svg?style=flat-square)](https://github.com/astral-sh/ruff)
 [![PyPI Downloads](https://static.pepy.tech/badge/netcheck)](https://pypi.org/project/netcheck?style=flat-square)
 [![License](https://img.shields.io/github/license/hardbyte/netchecks?style=flat-square)](/LICENSE)
@@ -28,7 +28,7 @@
 **Netchecks** is a set of tools for testing network conditions and asserting that they are as expected.
 
 There are two main components:
-- **Netchecks Operator** - Kubernetes Operator (Rust/kube-rs) that runs network checks and reports results as `PolicyReport` resources. See the [operator README](https://github.com/hardbyte/netchecks/blob/main/operator/README.md) for more details and the full documentation can be found at [https://docs.netchecks.io](https://docs.netchecks.io)
+- **Netchecks Operator** - Kubernetes Operator (Rust/kube-rs) that runs network checks and reports results as `PolicyReport` resources. See the [operator README](https://github.com/hardbyte/netchecks/blob/main/operator/README.md) for more details and the full documentation can be found at [https://netchecks.io](https://netchecks.io)
 - **Netcheck CLI and Python Library** - Command line tool for running network checks and asserting that they are as expected. Keep reading for the quickstart guide.
 
 

--- a/docs/src/components/Container.jsx
+++ b/docs/src/components/Container.jsx
@@ -1,0 +1,10 @@
+import clsx from 'clsx'
+
+export function Container({ className, ...props }) {
+  return (
+    <div
+      className={clsx('mx-auto max-w-7xl px-4 sm:px-6 lg:px-8', className)}
+      {...props}
+    />
+  )
+}

--- a/docs/src/components/Features.jsx
+++ b/docs/src/components/Features.jsx
@@ -1,0 +1,94 @@
+import { Container } from '@/components/Container'
+
+const features = [
+  {
+    title: 'Proactive Monitoring',
+    description:
+      'Periodically probe the network to detect when security assumptions are violated. Continuous validation of live workload environments increases confidence in security controls.',
+    icon: ShieldIcon,
+  },
+  {
+    title: 'Cloud Native',
+    description:
+      'A Kubernetes operator configured by custom resources. Outputs use PolicyReports — an emerging standard used by Kyverno and other security tools.',
+    icon: CloudIcon,
+  },
+  {
+    title: 'Alerting and Reporting',
+    description:
+      'Outputs PolicyReports with Prometheus metrics. Integrate with Grafana, Slack, Discord, email, or MS Teams using Policy Reporter.',
+    icon: BellIcon,
+  },
+  {
+    title: 'Independent from Controls',
+    description:
+      'Verifies whether your cluster can carry out network activity, independent of how controls are implemented — NetworkPolicies, Cilium, or external firewalls.',
+    icon: LockIcon,
+  },
+]
+
+function ShieldIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+    </svg>
+  )
+}
+
+function CloudIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15Z" />
+    </svg>
+  )
+}
+
+function BellIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+    </svg>
+  )
+}
+
+function LockIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+    </svg>
+  )
+}
+
+export function Features() {
+  return (
+    <section id="features" className="bg-slate-50 py-20 dark:bg-slate-800/50 sm:py-28">
+      <Container>
+        <div className="text-center">
+          <h2 className="font-display text-3xl tracking-tight text-slate-900 dark:text-white sm:text-4xl">
+            Concerned your security controls could be weakened?
+          </h2>
+          <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">
+            Actively test your cloud infrastructure with automated, declarative
+            network assertions.
+          </p>
+        </div>
+        <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="rounded-2xl border border-slate-200 bg-white p-8 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <feature.icon className="h-8 w-8 text-sky-500" />
+              <h3 className="mt-4 font-display text-lg font-medium text-slate-900 dark:text-white">
+                {feature.title}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+                {feature.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/docs/src/components/Footer.jsx
+++ b/docs/src/components/Footer.jsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { Container } from '@/components/Container'
+import { Logomark } from '@/components/Logo'
+
+export function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-white py-12 dark:border-slate-800 dark:bg-slate-900">
+      <Container>
+        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
+          <div className="flex items-center gap-3">
+            <Logomark className="h-7 w-7" />
+            <span className="text-sm text-slate-600 dark:text-slate-400">
+              Netchecks
+            </span>
+          </div>
+          <nav className="flex gap-6 text-sm text-slate-600 dark:text-slate-400">
+            <Link href="/docs/getting-started" className="hover:text-slate-900 dark:hover:text-white">
+              Docs
+            </Link>
+            <Link href="/docs/compliance" className="hover:text-slate-900 dark:hover:text-white">
+              Compliance
+            </Link>
+            <Link href="https://github.com/hardbyte/netchecks" className="hover:text-slate-900 dark:hover:text-white">
+              GitHub
+            </Link>
+          </nav>
+          <p className="text-sm text-slate-500 dark:text-slate-500">
+            &copy; {new Date().getFullYear()} Netchecks
+          </p>
+        </div>
+      </Container>
+    </footer>
+  )
+}

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import {useRouter} from 'next/router'
 import clsx from 'clsx'
 
-import {Hero} from '@/components/Hero'
 import {Logo, Logomark} from '@/components/Logo'
 import {MobileNavigation} from '@/components/MobileNavigation'
 import {Navigation} from '@/components/Navigation'
@@ -15,7 +14,7 @@ const navigation = [
     {
         title: 'Introduction',
         links: [
-            {title: 'Getting started', href: '/'},
+            {title: 'Getting started', href: '/docs/getting-started'},
             {title: 'Validating HTTP Controls', href: '/docs/http'},
             {title: 'Validating DNS Controls', href: '/docs/dns'},
             {title: 'Validating TCP Connectivity', href: '/docs/tcp'},
@@ -26,24 +25,17 @@ const navigation = [
         title: 'User Guide',
         links: [
             {title: 'Installation', href: '/docs/installation'},
-
             {title: 'Custom Validation Rules', href: '/docs/custom-validation-rules'},
             {title: 'External Data', href: '/docs/external-data'},
             {title: 'Alerting', href: '/docs/alerting'},
+            {title: 'Compliance', href: '/docs/compliance'},
         ],
     },
-    // {
-    //     title: 'Examples',
-    //     links: [
-    //
-    //     ],
-    // },
-
     {
         title: 'Contributor Guide',
         links: [
             {title: 'How to contribute', href: '/docs/how-to-contribute'},
-            {title: 'Development', href: '/docs/development',},
+            {title: 'Development', href: '/docs/development'},
             {title: 'Architecture guide', href: '/docs/architecture-guide'},
             {title: 'Testing', href: '/docs/testing'},
             {title: 'Design principles', href: '/docs/design-principles'},
@@ -55,13 +47,9 @@ const navigation = [
     {
       title: 'Reference',
       links: [
-        {title: 'Core concepts', href: '/docs/core-concepts'}
-        // { title: 'http', href: '/docs/http' },
-        // { title: 'dns', href: '/docs/dns' },
-        // { title: 'ping', href: '/docs/ping' },
+        {title: 'Core concepts', href: '/docs/core-concepts'},
       ],
     },
-
 ]
 
 function GitHubIcon(props) {
@@ -167,7 +155,6 @@ function useTableOfContents(tableOfContents) {
 
 export function Layout({children, title, tableOfContents}) {
     let router = useRouter()
-    let isHomePage = router.pathname === '/'
     let allLinks = navigation.flatMap((section) => section.links)
     let linkIndex = allLinks.findIndex((link) => link.href === router.pathname)
     let previousPage = allLinks[linkIndex - 1]
@@ -190,8 +177,6 @@ export function Layout({children, title, tableOfContents}) {
     return (
         <>
             <Header navigation={navigation}/>
-
-            {isHomePage && <Hero/>}
 
             <div className="relative mx-auto flex max-w-8xl justify-center sm:px-2 lg:px-8 xl:px-12">
                 <div className="hidden lg:relative lg:block lg:flex-none">

--- a/docs/src/components/MarketingHero.jsx
+++ b/docs/src/components/MarketingHero.jsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/Button'
+import { HeroBackground } from '@/components/HeroBackground'
+import { Container } from '@/components/Container'
+
+export function MarketingHero() {
+  return (
+    <div className="overflow-hidden bg-slate-900">
+      <div className="py-20 sm:px-2 lg:relative lg:py-28 lg:px-0">
+        <div className="mx-auto max-w-2xl items-center px-4 lg:max-w-8xl lg:px-8 xl:px-12">
+          <div className="relative z-10 text-center">
+            <div className="absolute inset-0 -z-10 flex justify-center">
+              <HeroBackground className="opacity-30 w-full max-w-3xl" />
+            </div>
+            <div className="relative">
+              <h1 className="inline bg-gradient-to-r from-indigo-200 via-sky-400 to-indigo-200 bg-clip-text font-display text-5xl tracking-tight text-transparent sm:text-7xl">
+                Verify your security controls are working
+              </h1>
+              <p className="mx-auto mt-6 max-w-2xl text-lg tracking-tight text-slate-400">
+                Netchecks proactively tests your Kubernetes network policies and
+                security controls. Cloud native, policy as code, no assumptions
+                about your implementation.
+              </p>
+              <div className="mt-10 flex justify-center gap-4">
+                <Button href="/docs/getting-started">Get started</Button>
+                <Button
+                  href="https://github.com/hardbyte/netchecks"
+                  variant="secondary"
+                >
+                  View on GitHub
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs/src/components/Pricing.jsx
+++ b/docs/src/components/Pricing.jsx
@@ -1,0 +1,120 @@
+import { Container } from '@/components/Container'
+import { Button } from '@/components/Button'
+
+function CheckIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" {...props}>
+      <path
+        d="M9.307 12.248a.75.75 0 1 0-1.114 1.004l1.114-1.004ZM11 15.25l-.557.502a.75.75 0 0 0 1.15-.043L11 15.25Zm4.844-5.041a.75.75 0 0 0-1.188-.918l1.188.918Zm-7.651 3.043 2.25 2.5 1.114-1.004-2.25-2.5-1.114 1.004Zm3.4 2.457 4.25-5.5-1.187-.918-4.25 5.5 1.188.918Z"
+        fill="currentColor"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="8.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+const plans = [
+  {
+    name: 'Open Source',
+    price: 'Free',
+    description:
+      'For security professionals, small businesses, students, hobbyists, and open source projects.',
+    href: '/docs/getting-started',
+    cta: 'Get started',
+    featured: true,
+    features: [
+      'Unlimited operator installs',
+      'Unlimited NetworkAssertions',
+      'HTTP, DNS, and TCP probes',
+      'PolicyReports & Prometheus metrics',
+      'Community support via GitHub',
+    ],
+  },
+  {
+    name: 'Compliance Pro',
+    price: 'Contact us',
+    description:
+      'Automated compliance reporting for regulated environments.',
+    href: 'https://buy.stripe.com/cN25or9rA8Ur6xa4gi',
+    cta: 'Get Compliance Pro',
+    featured: false,
+    features: [
+      'Everything in Open Source',
+      'CIS Kubernetes Benchmark checks',
+      'PCI-DSS v4 network controls',
+      'SOC 2 network monitoring evidence',
+      'Exportable compliance reports',
+      'Priority support',
+    ],
+  },
+]
+
+export function Pricing() {
+  return (
+    <section id="pricing" className="bg-slate-900 py-20 sm:py-28">
+      <Container>
+        <div className="text-center">
+          <h2 className="font-display text-3xl tracking-tight text-white sm:text-4xl">
+            Simple pricing, for everyone
+          </h2>
+          <p className="mt-4 text-lg text-slate-400">
+            Open source at its core. Compliance features when you need them.
+          </p>
+        </div>
+        <div className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-8 lg:grid-cols-2">
+          {plans.map((plan) => (
+            <div
+              key={plan.name}
+              className={`rounded-3xl px-6 py-8 sm:px-8 ${
+                plan.featured
+                  ? 'bg-sky-500 ring-1 ring-sky-500'
+                  : 'ring-1 ring-slate-700'
+              }`}
+            >
+              <h3 className="font-display text-2xl text-white">
+                {plan.name}
+              </h3>
+              <p
+                className={`mt-2 text-sm ${
+                  plan.featured ? 'text-sky-100' : 'text-slate-400'
+                }`}
+              >
+                {plan.description}
+              </p>
+              <p className="mt-6 font-display text-4xl font-light tracking-tight text-white">
+                {plan.price}
+              </p>
+              <ul className="mt-8 space-y-3 text-sm text-white">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex">
+                    <CheckIcon
+                      className={`h-6 w-6 flex-none ${
+                        plan.featured ? 'text-white' : 'text-slate-400'
+                      }`}
+                    />
+                    <span className="ml-3">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                href={plan.href}
+                variant={plan.featured ? 'primary' : 'secondary'}
+                className="mt-8 w-full justify-center"
+              >
+                {plan.cta}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/docs/src/pages/_app.jsx
+++ b/docs/src/pages/_app.jsx
@@ -61,6 +61,14 @@ export default function App({ Component, pageProps }) {
     ? collectHeadings(pageProps.markdoc.content)
     : []
 
+  let getLayout =
+    Component.getLayout ??
+    ((page) => (
+      <Layout title={title} tableOfContents={tableOfContents}>
+        {page}
+      </Layout>
+    ))
+
   return (
     <>
       <Head>
@@ -79,9 +87,7 @@ export default function App({ Component, pageProps }) {
         <meta name="theme-color" content="#ffffff"/>
 
       </Head>
-      <Layout title={title} tableOfContents={tableOfContents}>
-        <Component {...pageProps} />
-      </Layout>
+      {getLayout(<Component {...pageProps} />)}
     </>
   )
 }

--- a/docs/src/pages/docs/architecture-guide.md
+++ b/docs/src/pages/docs/architecture-guide.md
@@ -3,14 +3,16 @@ title: Architecture guide
 description: Netchecks architecture overview.
 ---
 
-Netchecks runs in Kubernetes as an [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). The 
-operator is implemented in Python using the [kopf](https://kopf.readthedocs.io/en/stable) framework.
+Netchecks runs in Kubernetes as an [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). Since v0.7.0, the operator is implemented in Rust using [kube-rs](https://kube.rs/) 3.0. It runs as a minimal distroless container based on [chainguard/static](https://images.chainguard.dev/directory/image/static/overview).
 
 The netchecks operator:
-- Listens for `NetworkAssertion` resources across the kubernetes cluster and creates `CronJobs` (or `Jobs`) for each of them.
+- Watches for `NetworkAssertion` resources across the cluster and reconciles `CronJobs` (or `Jobs`) for each of them. CronJobs are tracked via `.owns(cronjobs)` so changes are automatically detected.
 - Probe pods are created by the `CronJob` and run the tests that make up a particular network assertion. External data may be mounted into the Pod for use by the probe.
-- Listens for _probe_ Pods created by the NetworkAssertion's CronJob and parses assertion results from the Pod logs.
+- Parses assertion results from completed probe Pod logs.
 - Creates and updates `PolicyReport` resources for each NetworkAssertion in response to the assertion results.
+- Writes status conditions back to `NetworkAssertion` resources to reflect reconciliation state.
+- Exposes health endpoints (`/livez`, `/readyz`) for liveness and readiness probes.
+- Uses structured JSON logging via the `tracing` crate, with optional OTLP metrics export.
 
 Each probe pod uses the `netchecks` docker image to run the tests that make up a particular network assertion.
 
@@ -19,7 +21,7 @@ Each probe pod uses the `netchecks` docker image to run the tests that make up a
 
 ---
 
-The `netchecks` image is based on the [python:3.12-slim-bookworm](https://hub.docker.com/_/python) image.
+The `netchecks` probe image is based on the [python:3.12-slim-bookworm](https://hub.docker.com/_/python) image.
 
 [Kyverno's PolicyReporter](https://kyverno.github.io/policy-reporter/) is optionally installed alongside Netchecks to
 provide a convenient way to expose metrics, view the results, and generate notifications.

--- a/docs/src/pages/docs/compliance.md
+++ b/docs/src/pages/docs/compliance.md
@@ -1,0 +1,73 @@
+---
+title: Compliance Reporting
+description: Automated compliance evidence for regulated Kubernetes environments.
+---
+
+Netchecks **Compliance Pro** provides automated compliance reporting for regulated Kubernetes environments. Generate evidence for auditors that your network security controls are continuously tested and working.
+
+---
+
+## Supported Frameworks
+
+### CIS Kubernetes Benchmark
+
+Automatically verify network-related CIS controls:
+
+- Network policy enforcement between namespaces
+- API server access restrictions
+- DNS policy compliance
+- Egress filtering validation
+
+### PCI-DSS v4
+
+Generate evidence for PCI-DSS v4 network segmentation requirements:
+
+- Cardholder data environment isolation testing
+- Firewall and network policy validation
+- Periodic automated verification of segmentation controls
+
+### SOC 2
+
+Continuous monitoring evidence for SOC 2 Type II:
+
+- Network security monitoring assertions
+- Change detection for network policies
+- Automated evidence collection for audit periods
+
+---
+
+## How It Works
+
+Compliance Pro builds on the open source Netchecks operator. You define NetworkAssertions that map to compliance controls, and Netchecks continuously runs them on a schedule. Results are stored as PolicyReports and can be exported as compliance evidence.
+
+```yaml
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: pci-cde-isolation
+  namespace: cardholder-data
+  labels:
+    compliance/framework: pci-dss-v4
+    compliance/control: "1.3.1"
+  annotations:
+    description: Verify CDE namespace cannot reach public internet
+spec:
+  schedule: "*/15 * * * *"
+  rules:
+    - name: no-egress-to-internet
+      type: http
+      url: https://example.com
+      expected: fail
+      validate:
+        message: CDE should not have internet egress
+```
+
+---
+
+## Getting Started with Compliance Pro
+
+Compliance Pro includes exportable reports, framework-specific assertion templates, and priority support.
+
+[Get Compliance Pro](https://buy.stripe.com/cN25or9rA8Ur6xa4gi) to start generating automated compliance evidence for your Kubernetes clusters.
+
+For questions, [contact us](https://calendly.com/brian-thorne-netchecks/30min) to discuss your compliance requirements.

--- a/docs/src/pages/docs/development.md
+++ b/docs/src/pages/docs/development.md
@@ -1,22 +1,70 @@
 ---
 title: Operator Development
-description: Running during development
+description: Setting up a development environment for the Netchecks operator.
 ---
 
+The Netchecks operator is written in Rust using [kube-rs](https://kube.rs/). The probe CLI is written in Python.
+
+---
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) (latest stable)
+- [Docker](https://docs.docker.com/get-docker/)
+- [kind](https://kind.sigs.k8s.io/) for local Kubernetes clusters
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Helm](https://helm.sh/docs/intro/install/)
+- [uv](https://docs.astral.sh/uv/) for Python dependency management
 
 ## Start a test cluster
 
-If using [kind](https://kind.sigs.k8s.io/)
-
 ```shell
-kind create cluster
-kubectl config use-context kind-kind
+kind create cluster --name netchecks-test
 ```
 
-## Install the operator
+## Build the Docker images
 
-To install the operator from the repository
+Build both the probe and operator images locally:
 
-```bash
-helm upgrade --install netchecks-operator operator/charts/netchecks/ -n netchecks --create-namespace
+```shell
+docker build -t ghcr.io/hardbyte/netchecks:local .
+docker build -t ghcr.io/hardbyte/netchecks-operator:local operator/
+```
+
+Load them into Kind:
+
+```shell
+kind load docker-image ghcr.io/hardbyte/netchecks:local --name netchecks-test
+kind load docker-image ghcr.io/hardbyte/netchecks-operator:local --name netchecks-test
+```
+
+## Install the operator via Helm
+
+```shell
+helm dependency build operator/charts/netchecks
+helm upgrade --install netchecks-operator operator/charts/netchecks/ \
+  -n netchecks --create-namespace \
+  --set operator.image.tag=local \
+  --set netchecks.image.tag=local
+```
+
+## Building the Rust operator
+
+```shell
+cd operator
+cargo build --workspace
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## Running the Python probe tests
+
+```shell
+uv run pytest
+```
+
+## Cleanup
+
+```shell
+kind delete cluster --name netchecks-test
 ```

--- a/docs/src/pages/docs/getting-started.md
+++ b/docs/src/pages/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started
-pageTitle: Netchecks - Verifying your security controls
-description: A cloud native tool to dynamically declare a set of statements about the network (what should work and what shouldn't)
+pageTitle: Netchecks - Getting Started
+description: Learn how to get Netchecks set up in your own Kubernetes cluster.
 ---
 
 Learn how to get Netchecks set up in your own Kubernetes cluster. {% .lead %}
@@ -9,8 +9,8 @@ Learn how to get Netchecks set up in your own Kubernetes cluster. {% .lead %}
 ---
 ## Why does this exist?
 
-Like all software, security controls such as firewalls and network policies need validation to ensure they are working as intended. This is often done manually 
-as part of a one-off cyber-security review. Best practice is to configure automated checks that notify team members when a security control is not working as expected. 
+Like all software, security controls such as firewalls and network policies need validation to ensure they are working as intended. This is often done manually
+as part of a one-off cyber-security review. Best practice is to configure automated checks that notify team members when a security control is not working as expected.
 These can be as simple as a curl command in a cron job that tries to access a service that should be blocked and alerts if it succeeds. With Netchecks, you
 declare these checks declaratively and have them run automatically on a schedule, Netchecks will create PolicyReports that can be used for audit purposes, to trigger
 actions, alerts and notifications.
@@ -75,7 +75,7 @@ spec:
 
 {% callout title="What happens next?" %}
 Once you have applied the `NetworkAssertion`, Netchecks reacts by creating a `CronJob` in the
-same namespace to probe the network according to your schedule. After the first test has run 
+same namespace to probe the network according to your schedule. After the first test has run
 Netchecks creates a `PolicyReport` resource with the same name in the same namespace as the `NetworkAssertion`.
 The `PolicyReport` contains information about the test run and the results of the test.
 {% /callout %}
@@ -85,10 +85,10 @@ The `PolicyReport` contains information about the test run and the results of th
 
 {% quick-link title="Installation" icon="installation" href="/docs/installation" description="Step-by-step guides to setting up your system and installing the library." /%}
 
-{% quick-link title="Architecture guide" icon="presets" href="/" description="Learn how the internals work and contribute." /%}
+{% quick-link title="Architecture guide" icon="presets" href="/docs/architecture-guide" description="Learn how the internals work and contribute." /%}
 
-{% quick-link title="API reference" icon="theming" href="/" description="Learn to easily customize and modify your app's visual design to fit your brand." /%}
+{% quick-link title="HTTP Probes" icon="theming" href="/docs/http" description="Validate HTTP connectivity and security controls." /%}
 
-{% quick-link title="Examples" icon="plugins" href="/" description="See how others are using the library in their projects." /%}
+{% quick-link title="DNS Probes" icon="plugins" href="/docs/dns" description="Validate DNS resolution policies." /%}
 
 {% /quick-links %}

--- a/docs/src/pages/docs/how-to-contribute.md
+++ b/docs/src/pages/docs/how-to-contribute.md
@@ -31,5 +31,5 @@ on GitHub.
 
 ### Netcheck Operator
 
-The netchecks operator is implemented in Python using the [kopf](https://kopf.readthedocs.io/en/stable) framework
-and is available in the [operator](https://github.com/hardbyte/netchecks/tree/main/operator) folder on GitHub.
+The netchecks operator is implemented in Rust using [kube-rs](https://kube.rs/) and is available in the
+[operator](https://github.com/hardbyte/netchecks/tree/main/operator) folder on GitHub.

--- a/docs/src/pages/docs/testing.md
+++ b/docs/src/pages/docs/testing.md
@@ -5,9 +5,54 @@ description: Netchecks testing on GitHub Actions and locally.
 
 Both the Netchecks command line tool and Kubernetes operator have comprehensive test suites that run on GitHub Actions after every commit. The GitHub Actions workflows for testing can be found [here](https://github.com/hardbyte/netchecks/tree/main/.github/workflows).
 
+---
 
 ## Testing the Netchecks Python Library
+
+Unit tests for the Python probe:
 
 ```bash
 uv run pytest
 ```
+
+## Testing the Rust Operator
+
+Build and run clippy checks:
+
+```bash
+cd operator
+cargo build --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## Integration Tests with Kind
+
+The integration tests run the operator in a real Kubernetes cluster using [Kind](https://kind.sigs.k8s.io/). They are written in Python/pytest and use kubectl subprocess calls to interact with the cluster.
+
+### Setup
+
+```bash
+kind create cluster --name netchecks-test
+docker build -t ghcr.io/hardbyte/netchecks:local .
+docker build -t ghcr.io/hardbyte/netchecks-operator:local operator/
+kind load docker-image ghcr.io/hardbyte/netchecks:local --name netchecks-test
+kind load docker-image ghcr.io/hardbyte/netchecks-operator:local --name netchecks-test
+helm dependency build operator/charts/netchecks
+```
+
+### Running integration tests
+
+```bash
+cd operator
+NETCHECKS_IMAGE_TAG=local pytest -v -x
+```
+
+### Cleanup
+
+```bash
+kind delete cluster --name netchecks-test
+```
+
+{% callout title="Cilium tests" %}
+Some integration tests require Cilium CNI. These tests are automatically skipped when Cilium is not installed on the cluster.
+{% /callout %}

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -1,0 +1,25 @@
+import Head from 'next/head'
+import { MarketingHero } from '@/components/MarketingHero'
+import { Features } from '@/components/Features'
+import { Pricing } from '@/components/Pricing'
+import { Footer } from '@/components/Footer'
+
+export default function IndexPage() {
+  return (
+    <>
+      <Head>
+        <title>Netchecks - Verify your security controls are working</title>
+        <meta
+          name="description"
+          content="Netchecks proactively tests your Kubernetes network policies and security controls. Cloud native, policy as code."
+        />
+      </Head>
+      <MarketingHero />
+      <Features />
+      <Pricing />
+      <Footer />
+    </>
+  )
+}
+
+IndexPage.getLayout = (page) => page

--- a/operator/charts/netchecks/Chart.yaml
+++ b/operator/charts/netchecks/Chart.yaml
@@ -53,7 +53,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Documentation
-      url: https://docs.netchecks.io
+      url: https://netchecks.io
   artifacthub.io/crds: |
     - kind: NetworkAssertion
       version: v1

--- a/operator/charts/netchecks/README.md
+++ b/operator/charts/netchecks/README.md
@@ -7,7 +7,7 @@ Netchecks is written and maintained by Brian Thorne [@hardbyte](https://github.c
 
 ## Documentation
 
-The full documentation can be found at [docs.netchecks.io](https://docs.netchecks.io/) and the [GitHub repository](https://github.com/hardbyte/netchecks/tree/main/operator).
+The full documentation can be found at [netchecks.io](https://netchecks.io/) and the [GitHub repository](https://github.com/hardbyte/netchecks/tree/main/operator).
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ The full documentation can be found at [docs.netchecks.io](https://docs.netcheck
 
 ## Installing the Chart
 
-Full installation instructions can be found in the [documentation installation page](https://docs.netchecks.io/docs/installation).
+Full installation instructions can be found in the [documentation installation page](https://netchecks.io/docs/installation).
 
 To install the chart
 

--- a/operator/charts/netchecks/templates/NOTES.txt
+++ b/operator/charts/netchecks/templates/NOTES.txt
@@ -3,4 +3,4 @@ Thank you for installing {{ .Chart.Name | upper }}.
 
 Your release is named {{ .Release.Name }}.
 
-https://docs.netchecks.io
+https://netchecks.io


### PR DESCRIPTION
## Summary

- Add marketing landing page (Hero, Features, Pricing, Footer) to the docs site so `netchecks.io` serves a single unified site
- Move getting-started content to `/docs/getting-started`, add `/docs/compliance` page
- Use `getLayout` pattern so the homepage renders without docs sidebar chrome
- Flesh out stale development and testing docs with actual workflows
- Update all `docs.netchecks.io` references to `netchecks.io` across README, Helm chart, and templates

## Test plan

- [x] `npm run build` succeeds (22 pages generated)
- [ ] `npm run dev` — verify `/` shows marketing landing page without docs sidebar
- [ ] `/docs/getting-started` has the original getting-started content
- [ ] `/docs/compliance` shows compliance info with Stripe link
- [ ] All existing doc pages still render correctly
- [ ] After merge: apply Terraform changes in hardbyte-iac to point `netchecks.io` CNAME to `netchecks-docs.pages.dev`
- [ ] Set up `docs.netchecks.io → netchecks.io` 301 redirect via Cloudflare