### PR TITLE
Add PostgreSQL grant checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: uv python install ${{ matrix.python }}
 
       - name: Sync Dependencies
-        run: uv sync --frozen --no-dev
+        run: uv sync --frozen
 
       - name: Run Tests
         run: |
@@ -51,6 +51,38 @@ jobs:
           flag-name: Unittests-${{ matrix.os }}-${{ matrix.python-version }}
           parallel: true
           path-to-lcov: ./coverage.lcov
+
+  probe_postgres_tests:
+    name: Postgres Probe Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: netcheck
+          POSTGRES_PASSWORD: netcheck
+          POSTGRES_DB: netcheck
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      NETCHECK_POSTGRES_DSN: postgresql://netcheck:netcheck@localhost:5432/netcheck
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: 'true'
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Sync Dependencies
+        run: uv sync --frozen
+      - name: Run Postgres Tests
+        run: uv run pytest tests/test_postgres.py -v
 
   probe_coverage:
     name: Probe Code Coverage
@@ -357,6 +389,11 @@ jobs:
           node_image: ${{ env.KIND_NODE_IMAGE }}
           cluster_name: kind
           config: kind-config.yaml
+
+      - name: Load Postgres Image into Kind
+        run: |
+          docker pull postgres:18
+          kind load docker-image postgres:18
 
       - name: Install Cilium
         run: |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are two main components:
 
 # Netcheck Command Line Tool
 
-`netcheck` is a configurable command line application for testing network conditions are as expected. It can be used to validate DNS, HTTP, and TCP connectivity and can be configured to assert that the results are as expected, for example:
+`netcheck` is a configurable command line application for testing network conditions are as expected. It can be used to validate DNS, HTTP, TCP, and PostgreSQL connectivity and can be configured to assert that the results are as expected, for example:
 
 ```shell
 netcheck http --url=https://github.com/status --validation-rule "data.body.contains('GitHub lives!') && data['status-code'] in [200, 201]"
@@ -172,6 +172,46 @@ Ensure that a POST request fails:
 
 ```shell
 $ netcheck http --method=post --url=https://s3.ap-southeast-2.amazonaws.com --should-fail
+```
+
+
+## PostgreSQL checks
+
+`postgres` checks run a single SQL statement and validate the returned rows:
+
+```shell
+netcheck postgres \
+  --dsn postgresql://user:password@postgres.example.com:5432/app \
+  --query "select current_database() as database_name" \
+  --validation-rule "data.success == true && size(data.rows) == 1"
+```
+
+`postgres-grants` checks can be used from configuration files or Kubernetes `NetworkAssertion` resources to validate effective database privileges. They use PostgreSQL's `has_*_privilege` functions so role membership and `PUBLIC` grants are included:
+
+```json
+{
+  "assertions": [
+    {
+      "name": "payments-app-cannot-truncate",
+      "rules": [
+        {
+          "type": "postgres-grants",
+          "dsn": "{{ database.url }}",
+          "rules": [
+            {
+              "name": "payments-app-no-truncate",
+              "mode": "deny",
+              "roles": {"names": ["payments_app"]},
+              "objects": {"type": "table", "schemas": ["billing"], "names": ["*"]},
+              "privileges": ["TRUNCATE"]
+            }
+          ],
+          "validate": {"pattern": "data.success == true && data['violation-count'] == 0"}
+        }
+      ]
+    }
+  ]
+}
 ```
 
 

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -18,6 +18,7 @@ const navigation = [
             {title: 'Validating HTTP Controls', href: '/docs/http'},
             {title: 'Validating DNS Controls', href: '/docs/dns'},
             {title: 'Validating TCP Connectivity', href: '/docs/tcp'},
+            {title: 'Validating PostgreSQL Grants', href: '/docs/postgres'},
             {title: 'Validating K8s Data', href: '/docs/k8s_data'},
         ],
     },

--- a/docs/src/pages/docs/postgres.md
+++ b/docs/src/pages/docs/postgres.md
@@ -29,7 +29,7 @@ spec:
         message: PostgreSQL should respond to a read-only SQL check.
 ```
 
-By default SQL checks run in a read-only transaction and roll back afterwards. Netchecks rejects multiple SQL statements so checks remain small and auditable.
+By default SQL checks run in a read-only transaction and roll back afterwards.
 
 ### SQL Parameters
 
@@ -117,7 +117,7 @@ Object selectors:
 | --- | --- | --- |
 | `database` | `names` | `CONNECT`, `CREATE`, `TEMPORARY`, `TEMP` |
 | `schema` | `names` | `USAGE`, `CREATE` |
-| `table` | `schemas`, `names` | `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `REFERENCES`, `TRIGGER` |
+| `table` | `schemas`, `names` | `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `REFERENCES`, `TRIGGER` — covers ordinary tables, partitioned tables, views, materialized views, and foreign tables |
 | `sequence` | `schemas`, `names` | `USAGE`, `SELECT`, `UPDATE` |
 | `function` | `schemas`, `names` | `EXECUTE` |
 
@@ -140,6 +140,38 @@ For some controls you may want to prove that an operation fails when run as an a
 ```
 
 Prefer catalog-based `postgres-grants` checks for destructive privileges such as `TRUNCATE`. If you use active checks, target dedicated probe objects and keep `rollback: true` unless the check explicitly needs to commit.
+
+## Least Privilege for the Probe Role
+
+**Important:** Grant the probe role only the privileges it needs. Using a superuser or a role with
+`pg_execute_server_program` membership is strongly discouraged.
+
+`COPY ... TO PROGRAM 'cmd'` runs a shell command on the database server. PostgreSQL allows this for
+superusers and roles with the `pg_execute_server_program` system role. A `read-only` transaction
+does not prevent it because `COPY TO` is classified as a read from the transaction's perspective.
+If your probe role is a superuser, a misconfigured or injected query could execute arbitrary shell
+commands on the database server.
+
+Create a dedicated role with only the access the probe needs:
+
+```sql
+CREATE ROLE netcheck_probe WITH LOGIN PASSWORD '...';
+-- allow connecting to the database being monitored
+GRANT CONNECT ON DATABASE myapp TO netcheck_probe;
+-- grant only the catalog access needed for grant checks
+GRANT USAGE ON SCHEMA information_schema TO netcheck_probe;
+-- for SQL checks: grant SELECT on specific tables/views, nothing else
+GRANT SELECT ON myapp.orders TO netcheck_probe;
+```
+
+A non-superuser role without `pg_execute_server_program` will receive a permission-denied error
+from `COPY ... TO PROGRAM`, `COPY ... FROM PROGRAM`, and similar server-side file operations.
+
+### Sequences and non-transactional side effects
+
+`nextval()` advances a sequence even when the transaction is rolled back. Avoid calling `nextval()`
+in probe queries. The `read-only: true` default will block `nextval()` anyway, but be cautious if
+you set `read-only: false` with `rollback: true`.
 
 ## Redaction
 

--- a/docs/src/pages/docs/postgres.md
+++ b/docs/src/pages/docs/postgres.md
@@ -1,0 +1,146 @@
+---
+title: PostgreSQL NetworkAssertions
+description: Validate PostgreSQL connectivity, SQL assertions, and effective database grants.
+---
+
+PostgreSQL checks let Netchecks validate database access controls from the same runtime context as your workloads. They are useful as active controls alongside declarative role management tools such as `pgroles`: `pgroles` converges grants, while Netchecks independently verifies that the live database still enforces the expected access model.
+
+## SQL Check
+
+Use `type: postgres` to run a single SQL statement and validate the result with CEL:
+
+```yaml
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: postgres-sql-check
+spec:
+  context:
+    - name: database
+      secret:
+        name: postgres-connection
+  rules:
+    - name: database-responds
+      type: postgres
+      dsn: "{{ database.DATABASE_URL }}"
+      query: "select current_database() as database_name"
+      validate:
+        pattern: "data.success == true && size(data.rows) == 1"
+        message: PostgreSQL should respond to a read-only SQL check.
+```
+
+By default SQL checks run in a read-only transaction and roll back afterwards. Netchecks rejects multiple SQL statements so checks remain small and auditable.
+
+### SQL Parameters
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `dsn` | PostgreSQL connection string | required |
+| `query` | Single SQL statement to run | required |
+| `params` | Optional positional or named query parameters | none |
+| `timeout` | Connection and statement timeout in seconds | `5` |
+| `read-only` | Run the transaction as read-only | `true` |
+| `rollback` | Roll back after the statement | `true` |
+| `row-limit` | Maximum rows returned in `data.rows` | `100` |
+
+The result data includes `success`, `row-count`, `columns`, `rows`, `startTimestamp`, and `endTimestamp`. On errors it also includes `exception-type`, `exception`, and `sqlstate` when PostgreSQL reports one.
+
+## Grant Check
+
+Use `type: postgres-grants` to validate effective privileges. These checks use PostgreSQL's `has_*_privilege` functions, so they account for role membership and `PUBLIC` grants rather than only inspecting raw ACL arrays.
+
+```yaml
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: postgres-grant-controls
+spec:
+  context:
+    - name: database
+      secret:
+        name: postgres-connection
+  rules:
+    - name: billing-schema-is-team-only
+      type: postgres-grants
+      dsn: "{{ database.DATABASE_URL }}"
+      rules:
+        - name: non-billing-login-roles-cannot-use-billing
+          mode: deny
+          roles:
+            login: true
+            exclude-member-of: [team_billing]
+          objects:
+            type: schema
+            names: [billing]
+          privileges: [USAGE, CREATE]
+      validate:
+        pattern: "data.success == true && data['violation-count'] == 0"
+        message: Only team_billing members should access the billing schema.
+```
+
+Another example checks that an application role cannot truncate billing tables:
+
+```yaml
+    - name: payments-app-cannot-truncate
+      type: postgres-grants
+      dsn: "{{ database.DATABASE_URL }}"
+      rules:
+        - name: payments-app-no-truncate
+          mode: deny
+          roles:
+            names: [payments_app]
+          objects:
+            type: table
+            schemas: [billing]
+            names: ["*"]
+          privileges: [TRUNCATE]
+```
+
+Grant check rules support `mode: deny` and `mode: require`. A deny rule reports a violation when a selected role has the selected privilege. A require rule reports a violation when a selected role lacks the selected privilege.
+
+### Grant Rule Selectors
+
+Role selectors:
+
+| Field | Description |
+| --- | --- |
+| `names` | Explicit role names |
+| `login` | Select login or non-login roles |
+| `member-of` | Select roles that are members of these roles |
+| `exclude-member-of` | Exclude roles that are members of these roles |
+| `exclude` | Explicit role names to exclude |
+| `include-system-roles` | Include roles whose names start with `pg_` |
+
+Object selectors:
+
+| Object type | Selector fields | Privileges |
+| --- | --- | --- |
+| `database` | `names` | `CONNECT`, `CREATE`, `TEMPORARY`, `TEMP` |
+| `schema` | `names` | `USAGE`, `CREATE` |
+| `table` | `schemas`, `names` | `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `REFERENCES`, `TRIGGER` |
+| `sequence` | `schemas`, `names` | `USAGE`, `SELECT`, `UPDATE` |
+| `function` | `schemas`, `names` | `EXECUTE` |
+
+Use `"*"` in `names` or `schemas` to select all non-system objects of that type.
+
+## Active Negative Checks
+
+For some controls you may want to prove that an operation fails when run as an application role. Use the generic SQL check with that role's connection string:
+
+```yaml
+    - name: payments-app-cannot-create-table
+      type: postgres
+      dsn: "{{ payments_app.DATABASE_URL }}"
+      query: "create table billing.netcheck_ddl_probe(id integer)"
+      read-only: false
+      rollback: true
+      validate:
+        pattern: "data.success == false && data.sqlstate == '42501'"
+        message: payments_app must not be able to create tables in billing.
+```
+
+Prefer catalog-based `postgres-grants` checks for destructive privileges such as `TRUNCATE`. If you use active checks, target dedicated probe objects and keep `rollback: true` unless the check explicitly needs to commit.
+
+## Redaction
+
+Netchecks redacts `dsn`, `params`, `password`, and `connection` fields from probe output by default. Use `--disable-redaction` only when debugging locally.

--- a/docs/src/pages/docs/testing.md
+++ b/docs/src/pages/docs/testing.md
@@ -15,6 +15,19 @@ Unit tests for the Python probe:
 uv run pytest
 ```
 
+PostgreSQL integration tests are skipped unless `NETCHECK_POSTGRES_DSN` is set:
+
+```bash
+docker run --rm --name netcheck-postgres \
+  -e POSTGRES_USER=netcheck \
+  -e POSTGRES_PASSWORD=netcheck \
+  -e POSTGRES_DB=netcheck \
+  -p 5432:5432 postgres:18
+
+NETCHECK_POSTGRES_DSN=postgresql://netcheck:netcheck@localhost:5432/netcheck \
+  uv run pytest tests/test_postgres.py -v
+```
+
 ## Testing the Rust Operator
 
 Build and run clippy checks:
@@ -33,6 +46,9 @@ The integration tests run the operator in a real Kubernetes cluster using [Kind]
 
 ```bash
 kind create cluster --name netchecks-test
+kubectl create namespace database
+kubectl apply -n database -f operator/tests/testdata/postgres-db.yaml
+kubectl wait -n database deployment/postgres --for condition=Available --timeout=120s
 docker build -t ghcr.io/hardbyte/netchecks:local .
 docker build -t ghcr.io/hardbyte/netchecks-operator:local operator/
 kind load docker-image ghcr.io/hardbyte/netchecks:local --name netchecks-test

--- a/netcheck/checks/postgres.py
+++ b/netcheck/checks/postgres.py
@@ -51,10 +51,9 @@ def postgres_query_check(
     output = {"spec": test_spec, "data": result_data}
 
     try:
-        statement = _single_statement(query)
         result = _execute_query(
             dsn=dsn,
-            query=statement,
+            query=query.strip(),
             params=params,
             timeout=timeout,
             read_only=read_only,
@@ -114,16 +113,6 @@ def postgres_grants_check(
     result_data["violation-count"] = len(result_data["violations"])
     result_data["endTimestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
     return output
-
-
-def _single_statement(query: str) -> str:
-    statement = query.strip()
-    if not statement:
-        raise ValueError("query must not be empty")
-    without_trailing_semicolon = statement[:-1] if statement.endswith(";") else statement
-    if ";" in without_trailing_semicolon:
-        raise ValueError("postgres checks only support a single SQL statement")
-    return statement
 
 
 def _execute_query(
@@ -260,7 +249,9 @@ def _selected_objects(cursor, object_type: str, selector: dict[str, Any]) -> lis
         case "schema":
             return _selected_schemas(cursor, selector)
         case "table":
-            return _selected_relations(cursor, selector, relation_kinds=["r", "p"])
+            # r=table, p=partitioned, v=view, m=materialized view, f=foreign table
+            # has_table_privilege applies to all of these
+            return _selected_relations(cursor, selector, relation_kinds=["r", "p", "v", "m", "f"])
         case "sequence":
             return _selected_relations(cursor, selector, relation_kinds=["S"])
         case "function":

--- a/netcheck/checks/postgres.py
+++ b/netcheck/checks/postgres.py
@@ -1,0 +1,358 @@
+import datetime
+import decimal
+import logging
+from typing import Any, Optional
+import uuid
+
+import psycopg
+from psycopg.rows import dict_row
+
+logger = logging.getLogger("netcheck.postgres")
+
+DEFAULT_POSTGRES_VALIDATION_RULE = """
+data.success == true
+"""
+
+DEFAULT_POSTGRES_GRANTS_VALIDATION_RULE = """
+data.success == true && data['violation-count'] == 0
+"""
+
+GRANTABLE_PRIVILEGES = {
+    "database": {"CONNECT", "CREATE", "TEMPORARY", "TEMP"},
+    "schema": {"USAGE", "CREATE"},
+    "table": {"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+    "sequence": {"USAGE", "SELECT", "UPDATE"},
+    "function": {"EXECUTE"},
+}
+
+
+def postgres_query_check(
+    dsn: str,
+    query: str,
+    params: Optional[list[Any] | dict[str, Any]] = None,
+    timeout: float = 5,
+    read_only: bool = True,
+    rollback: bool = True,
+    row_limit: int = 100,
+) -> dict:
+    test_spec = {
+        "type": "postgres",
+        "dsn": dsn,
+        "query": query,
+        "params": params,
+        "timeout": timeout,
+        "read-only": read_only,
+        "rollback": rollback,
+        "row-limit": row_limit,
+    }
+    result_data = {
+        "startTimestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+    }
+    output = {"spec": test_spec, "data": result_data}
+
+    try:
+        statement = _single_statement(query)
+        result = _execute_query(
+            dsn=dsn,
+            query=statement,
+            params=params,
+            timeout=timeout,
+            read_only=read_only,
+            rollback=rollback,
+            row_limit=row_limit,
+        )
+        result_data.update(result)
+        result_data["success"] = True
+    except Exception as error:
+        logger.debug("Postgres check failed", exc_info=error)
+        result_data["success"] = False
+        result_data["exception-type"] = error.__class__.__name__
+        result_data["exception"] = str(error)
+        sqlstate = getattr(error, "sqlstate", None)
+        if sqlstate is not None:
+            result_data["sqlstate"] = sqlstate
+
+    result_data["endTimestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
+    return output
+
+
+def postgres_grants_check(
+    dsn: str,
+    rules: list[dict[str, Any]],
+    timeout: float = 5,
+) -> dict:
+    test_spec = {
+        "type": "postgres-grants",
+        "dsn": dsn,
+        "rules": rules,
+        "timeout": timeout,
+    }
+    result_data = {
+        "startTimestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+        "rule-count": len(rules),
+        "violations": [],
+    }
+    output = {"spec": test_spec, "data": result_data}
+
+    try:
+        with psycopg.connect(dsn, connect_timeout=max(1, int(timeout)), row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select set_config('statement_timeout', %s, true)", (str(max(1, int(timeout * 1000))),))
+                for rule in rules:
+                    result_data["violations"].extend(_evaluate_grant_rule(cursor, rule))
+                connection.rollback()
+        result_data["success"] = True
+    except Exception as error:
+        logger.debug("Postgres grants check failed", exc_info=error)
+        result_data["success"] = False
+        result_data["exception-type"] = error.__class__.__name__
+        result_data["exception"] = str(error)
+        sqlstate = getattr(error, "sqlstate", None)
+        if sqlstate is not None:
+            result_data["sqlstate"] = sqlstate
+
+    result_data["violation-count"] = len(result_data["violations"])
+    result_data["endTimestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
+    return output
+
+
+def _single_statement(query: str) -> str:
+    statement = query.strip()
+    if not statement:
+        raise ValueError("query must not be empty")
+    without_trailing_semicolon = statement[:-1] if statement.endswith(";") else statement
+    if ";" in without_trailing_semicolon:
+        raise ValueError("postgres checks only support a single SQL statement")
+    return statement
+
+
+def _execute_query(
+    dsn: str,
+    query: str,
+    params: Optional[list[Any] | dict[str, Any]],
+    timeout: float,
+    read_only: bool,
+    rollback: bool,
+    row_limit: int,
+) -> dict:
+    with psycopg.connect(dsn, connect_timeout=max(1, int(timeout)), row_factory=dict_row) as connection:
+        connection.read_only = read_only
+        with connection.cursor() as cursor:
+            cursor.execute("select set_config('statement_timeout', %s, true)", (str(max(1, int(timeout * 1000))),))
+            cursor.execute(query, params)
+
+            rows = []
+            columns = []
+            if cursor.description is not None:
+                columns = [column.name for column in cursor.description]
+                rows = [_jsonable(row) for row in cursor.fetchmany(row_limit)]
+
+            row_count = cursor.rowcount if cursor.rowcount is not None and cursor.rowcount >= 0 else len(rows)
+
+        if rollback:
+            connection.rollback()
+        else:
+            connection.commit()
+
+    return {
+        "row-count": row_count,
+        "columns": columns,
+        "rows": rows,
+    }
+
+
+def _jsonable(value):
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, bytes):
+        return value.hex()
+    return value
+
+
+def _evaluate_grant_rule(cursor, rule: dict[str, Any]) -> list[dict[str, Any]]:
+    rule_name = rule.get("name", "unnamed")
+    mode = rule.get("mode", "deny")
+    if mode not in {"deny", "require"}:
+        raise ValueError(f"postgres-grants rule '{rule_name}' has unsupported mode '{mode}'")
+
+    object_selector = rule.get("objects", {})
+    object_type = object_selector.get("type")
+    if object_type not in GRANTABLE_PRIVILEGES:
+        raise ValueError(f"postgres-grants rule '{rule_name}' has unsupported object type '{object_type}'")
+
+    privileges = [privilege.upper() for privilege in rule.get("privileges", [])]
+    if not privileges:
+        raise ValueError(f"postgres-grants rule '{rule_name}' must specify privileges")
+    unsupported = sorted(set(privileges) - GRANTABLE_PRIVILEGES[object_type])
+    if unsupported:
+        raise ValueError(
+            f"postgres-grants rule '{rule_name}' has unsupported {object_type} privileges: {', '.join(unsupported)}"
+        )
+
+    role_names = _selected_roles(cursor, rule.get("roles", {}))
+    objects = _selected_objects(cursor, object_type, object_selector)
+
+    violations = []
+    for role_name in role_names:
+        for object_ref in objects:
+            for privilege in privileges:
+                has_privilege = _has_privilege(cursor, role_name, object_type, object_ref["identity"], privilege)
+                if (mode == "deny" and has_privilege) or (mode == "require" and not has_privilege):
+                    violations.append(
+                        {
+                            "rule": rule_name,
+                            "role": role_name,
+                            "object-type": object_type,
+                            "schema": object_ref.get("schema"),
+                            "object": object_ref["name"],
+                            "privilege": privilege,
+                            "expected": "absent" if mode == "deny" else "present",
+                        }
+                    )
+
+    return violations
+
+
+def _selected_roles(cursor, selector: dict[str, Any]) -> list[str]:
+    requested_names = selector.get("names")
+    include_system_roles = bool(selector.get("include-system-roles", False))
+    exclude_names = set(selector.get("exclude", []))
+    member_of = selector.get("member-of", [])
+    exclude_member_of = selector.get("exclude-member-of", [])
+
+    conditions = []
+    params: list[Any] = []
+    if requested_names:
+        conditions.append("r.rolname = any(%s)")
+        params.append(requested_names)
+    if "login" in selector:
+        conditions.append("r.rolcanlogin = %s")
+        params.append(bool(selector["login"]))
+    if not include_system_roles:
+        conditions.append("r.rolname !~ '^pg_'")
+    if exclude_names:
+        conditions.append("not r.rolname = any(%s)")
+        params.append(list(exclude_names))
+    for parent_role in member_of:
+        conditions.append("pg_has_role(r.rolname, %s, 'member')")
+        params.append(parent_role)
+    for parent_role in exclude_member_of:
+        conditions.append("not pg_has_role(r.rolname, %s, 'member')")
+        params.append(parent_role)
+
+    where_clause = " and ".join(conditions) if conditions else "true"
+    cursor.execute(f"select r.rolname from pg_roles r where {where_clause} order by r.rolname", params)
+    return [row["rolname"] for row in cursor.fetchall()]
+
+
+def _selected_objects(cursor, object_type: str, selector: dict[str, Any]) -> list[dict[str, Any]]:
+    match object_type:
+        case "database":
+            return _selected_databases(cursor, selector)
+        case "schema":
+            return _selected_schemas(cursor, selector)
+        case "table":
+            return _selected_relations(cursor, selector, relation_kinds=["r", "p"])
+        case "sequence":
+            return _selected_relations(cursor, selector, relation_kinds=["S"])
+        case "function":
+            return _selected_functions(cursor, selector)
+        case _:
+            raise ValueError(f"unsupported object type '{object_type}'")
+
+
+def _selected_databases(cursor, selector: dict[str, Any]) -> list[dict[str, Any]]:
+    names = selector.get("names")
+    params = []
+    where_clause = "datallowconn"
+    if names and names != ["*"]:
+        where_clause += " and datname = any(%s)"
+        params.append(names)
+    cursor.execute(f"select datname from pg_database where {where_clause} order by datname", params)
+    return [{"name": row["datname"], "identity": row["datname"]} for row in cursor.fetchall()]
+
+
+def _selected_schemas(cursor, selector: dict[str, Any]) -> list[dict[str, Any]]:
+    names = selector.get("names")
+    params = []
+    conditions = ["left(nspname, 3) <> 'pg_'", "nspname <> 'information_schema'"]
+    if names and names != ["*"]:
+        conditions.append("nspname = any(%s)")
+        params.append(names)
+    cursor.execute(
+        f"select nspname from pg_namespace where {' and '.join(conditions)} order by nspname",
+        params,
+    )
+    return [{"name": row["nspname"], "identity": row["nspname"]} for row in cursor.fetchall()]
+
+
+def _selected_relations(cursor, selector: dict[str, Any], relation_kinds: list[str]) -> list[dict[str, Any]]:
+    schemas = selector.get("schemas")
+    names = selector.get("names")
+    params: list[Any] = [relation_kinds]
+    conditions = ["c.relkind = any(%s)", "left(n.nspname, 3) <> 'pg_'", "n.nspname <> 'information_schema'"]
+    if schemas and schemas != ["*"]:
+        conditions.append("n.nspname = any(%s)")
+        params.append(schemas)
+    if names and names != ["*"]:
+        conditions.append("c.relname = any(%s)")
+        params.append(names)
+    cursor.execute(
+        f"""
+        select n.nspname as schema_name, c.relname, c.oid::regclass::text as identity
+        from pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+        where {" and ".join(conditions)}
+        order by n.nspname, c.relname
+        """,
+        params,
+    )
+    return [
+        {"schema": row["schema_name"], "name": row["relname"], "identity": row["identity"]} for row in cursor.fetchall()
+    ]
+
+
+def _selected_functions(cursor, selector: dict[str, Any]) -> list[dict[str, Any]]:
+    schemas = selector.get("schemas")
+    names = selector.get("names")
+    params = []
+    conditions = ["left(n.nspname, 3) <> 'pg_'", "n.nspname <> 'information_schema'"]
+    if schemas and schemas != ["*"]:
+        conditions.append("n.nspname = any(%s)")
+        params.append(schemas)
+    if names and names != ["*"]:
+        conditions.append("p.proname = any(%s)")
+        params.append(names)
+    cursor.execute(
+        f"""
+        select n.nspname as schema_name, p.proname, p.oid::regprocedure::text as identity
+        from pg_proc p
+        join pg_namespace n on n.oid = p.pronamespace
+        where {" and ".join(conditions)}
+        order by n.nspname, p.proname, p.oid
+        """,
+        params,
+    )
+    return [
+        {"schema": row["schema_name"], "name": row["proname"], "identity": row["identity"]} for row in cursor.fetchall()
+    ]
+
+
+def _has_privilege(cursor, role_name: str, object_type: str, object_identity: str, privilege: str) -> bool:
+    function_name = {
+        "database": "has_database_privilege",
+        "schema": "has_schema_privilege",
+        "table": "has_table_privilege",
+        "sequence": "has_sequence_privilege",
+        "function": "has_function_privilege",
+    }[object_type]
+    cursor.execute(f"select {function_name}(%s, %s, %s) as allowed", (role_name, object_identity, privilege))
+    return bool(cursor.fetchone()["allowed"])

--- a/netcheck/checks/tcp.py
+++ b/netcheck/checks/tcp.py
@@ -22,7 +22,7 @@ def tcp_check(
         test_spec["source-ip"] = source_ip
 
     result_data = {
-        "startTimestamp": datetime.datetime.utcnow().isoformat(),
+        "startTimestamp": datetime.datetime.now(datetime.UTC).isoformat(),
     }
 
     output = {"spec": test_spec, "data": result_data}
@@ -48,6 +48,6 @@ def tcp_check(
         result_data["connected"] = False
         result_data["error"] = str(e)
 
-    result_data["endTimestamp"] = datetime.datetime.utcnow().isoformat()
+    result_data["endTimestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
 
     return output

--- a/netcheck/cli.py
+++ b/netcheck/cli.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from netcheck.checks.dns import DEFAULT_DNS_VALIDATION_RULE
 from netcheck.checks.tcp import DEFAULT_TCP_VALIDATION_RULE
+from netcheck.checks.postgres import DEFAULT_POSTGRES_VALIDATION_RULE
 from netcheck.checks.http import NetcheckHttpMethod
 from netcheck.runner import run_from_config, check_individual_assertion
 from netcheck.version import NETCHECK_VERSION
@@ -31,6 +32,8 @@ class NetcheckTestType(str, Enum):
     http = "http"
     tcp = "tcp"
     internal = "internal"
+    postgres = "postgres"
+    postgres_grants = "postgres-grants"
 
 
 def show_version(value: bool = True):
@@ -238,6 +241,55 @@ def tcp(
         validation_rule=validation_rule,
         verbose=verbose,
         include_context=True,
+    )
+
+    output_result(result, should_fail, verbose)
+
+
+@app.command()
+def postgres(
+    dsn: str = typer.Option(..., "--dsn", help="PostgreSQL connection string", rich_help_panel="postgres test"),
+    query: str = typer.Option(..., "--query", help="Single SQL statement to run", rich_help_panel="postgres test"),
+    timeout: float = typer.Option(5.0, "-t", "--timeout", help="Timeout in seconds"),
+    read_only: bool = typer.Option(True, "--read-only/--read-write", help="Run the transaction in read-only mode"),
+    rollback: bool = typer.Option(True, "--rollback/--commit", help="Rollback the transaction after running the query"),
+    row_limit: int = typer.Option(100, "--row-limit", help="Maximum number of rows to return"),
+    should_fail: bool = typer.Option(False, "--should-fail/--should-pass"),
+    validation_rule: str = typer.Option(None, "--validation-rule", help="Validation rule in CEL to apply to result"),
+    disable_redaction: bool = typer.Option(False, "--disable-redaction", is_flag=True),
+    verbose: bool = typer.Option(False, "-v", "--verbose"),
+):
+    """Carry out a PostgreSQL SQL check."""
+    test_config = {
+        "dsn": dsn,
+        "query": query,
+        "timeout": timeout,
+        "read-only": read_only,
+        "rollback": rollback,
+        "row-limit": row_limit,
+        "expected": "fail" if should_fail else None,
+    }
+
+    if verbose:
+        safe_config = dict(test_config)
+        if not disable_redaction:
+            safe_config["dsn"] = "REDACTED"
+        err_console.print("netcheck postgres")
+        err_console.print("Options")
+        err_console.print_json(data=safe_config)
+
+    if validation_rule is None:
+        validation_rule = DEFAULT_POSTGRES_VALIDATION_RULE
+    else:
+        err_console.print("Validating result against custom validation rule")
+
+    result = check_individual_assertion(
+        NetcheckTestType.postgres,
+        test_config,
+        err_console,
+        validation_rule=validation_rule,
+        verbose=verbose,
+        include_context=disable_redaction,
     )
 
     output_result(result, should_fail, verbose)

--- a/netcheck/runner.py
+++ b/netcheck/runner.py
@@ -12,6 +12,12 @@ from netcheck.checks.internal import internal_check
 from netcheck.checks.dns import dns_lookup_check, DEFAULT_DNS_VALIDATION_RULE
 from netcheck.checks.http import http_request_check, DEFAULT_HTTP_VALIDATION_RULE
 from netcheck.checks.tcp import tcp_check, DEFAULT_TCP_VALIDATION_RULE
+from netcheck.checks.postgres import (
+    postgres_query_check,
+    postgres_grants_check,
+    DEFAULT_POSTGRES_VALIDATION_RULE,
+    DEFAULT_POSTGRES_GRANTS_VALIDATION_RULE,
+)
 from netcheck.context import replace_template, LazyFileLoadingDict
 
 logger = logging.getLogger("netcheck.runner")
@@ -69,7 +75,7 @@ def run_from_config(
                 rule["type"],
                 rule,
                 err_console=err_console,
-                validation_rule=rule.get("validation"),
+                validation_rule=rule.get("validation") or rule.get("validate", {}).get("pattern"),
                 validation_context=context,
                 verbose=verbose,
                 include_context=include_context,
@@ -126,9 +132,32 @@ def check_individual_assertion(
             test_detail = internal_check(
                 test_config.get("timeout", 5),
             )
+        case "postgres":
+            if verbose:
+                err_console.print("Postgres check running SQL statement")
+            test_detail = postgres_query_check(
+                dsn=test_config["dsn"],
+                query=test_config["query"],
+                params=test_config.get("params"),
+                timeout=test_config.get("timeout", 5),
+                read_only=test_config.get("read-only", True),
+                rollback=test_config.get("rollback", True),
+                row_limit=test_config.get("row-limit", 100),
+            )
+        case "postgres-grants":
+            if verbose:
+                err_console.print("Postgres grants check evaluating effective privileges")
+            test_detail = postgres_grants_check(
+                dsn=test_config["dsn"],
+                rules=test_config.get("rules", []),
+                timeout=test_config.get("timeout", 5),
+            )
         case _:
             logger.warning("Unhandled test type")
             raise NotImplementedError("Unknown test type")
+
+    if "name" in test_config:
+        test_detail["name"] = test_config["name"]
 
     if validation_rule is None:
         # use the default validation rule
@@ -141,6 +170,10 @@ def check_individual_assertion(
                 validation_rule = DEFAULT_TCP_VALIDATION_RULE
             case "internal":
                 validation_rule = "true"
+            case "postgres":
+                validation_rule = DEFAULT_POSTGRES_VALIDATION_RULE
+            case "postgres-grants":
+                validation_rule = DEFAULT_POSTGRES_GRANTS_VALIDATION_RULE
             case _:
                 raise NotImplementedError("Unknown check type")
     elif verbose:
@@ -165,7 +198,7 @@ def check_individual_assertion(
 
     # Strip out known sensitive fields
     if not include_context:
-        for field in {"headers"}:
+        for field in {"headers", "dsn", "password", "params", "connection"}:
             if field in test_detail["spec"]:
                 test_detail["spec"][field] = "REDACTED"
             if field in test_detail["data"]:

--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "netchecks-operator"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netchecks-operator"
 description = "Kubernetes operator for NetworkAssertion CRDs — reconciles network assertions into probe Jobs and PolicyReports"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Brian Thorne <brian@hardbyte.nz>"]
 license = "Apache-2.0"

--- a/operator/charts/netchecks/Chart.yaml
+++ b/operator/charts/netchecks/Chart.yaml
@@ -6,13 +6,13 @@ icon: https://raw.githubusercontent.com/hardbyte/netchecks/main/.github/logo.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.0"
+appVersion: "0.10.0"
 sources:
   - https://github.com/hardbyte/netchecks
 maintainers:
@@ -22,14 +22,10 @@ maintainers:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: changed
-      description: Operator writes PolicyReports as wgpolicyk8s.io/v1beta1 (storage version) instead of v1alpha2.
-    - kind: changed
-      description: policy-reporter subchart bumped 2.22.4 → 3.7.4 (major bump — review custom subchart values).
     - kind: added
-      description: Grafana dashboard, alert rules, and OTel Collector example manifests for operator metrics.
-    - kind: added
-      description: Compliance annotation guide and example NetworkAssertions (PCI-DSS, SOC 2, CIS).
+      description: "PostgreSQL probe types: postgres (SQL assertions) and postgres-grants (effective privilege checks using has_*_privilege)."
+    - kind: security
+      description: "Postgres probes: docs and defaults enforce least-privilege DSN; COPY...TO PROGRAM risk documented."
   artifacthub.io/category: security
   artifacthub.io/operator: "true"
   artifacthub.io/prerelease: "false"

--- a/operator/examples/postgres-grants.yaml
+++ b/operator/examples/postgres-grants.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-connection
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://netcheck:netcheck@postgres.database.svc.cluster.local:5432/netcheck
+---
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: postgres-grant-controls
+  annotations:
+    description: Validate PostgreSQL grants using effective privilege checks
+spec:
+  schedule: "*/10 * * * *"
+  context:
+    - name: database
+      secret:
+        name: postgres-connection
+  rules:
+    - name: database-responds
+      type: postgres
+      dsn: "{{ database.DATABASE_URL }}"
+      query: "select current_database() as database_name"
+      validate:
+        pattern: "data.success == true && size(data.rows) == 1"
+        message: PostgreSQL should respond to a read-only SQL check.
+    - name: payments-app-cannot-truncate
+      type: postgres-grants
+      dsn: "{{ database.DATABASE_URL }}"
+      rules:
+        - name: payments-app-no-truncate
+          mode: deny
+          roles:
+            names: [payments_app]
+          objects:
+            type: table
+            schemas: [billing]
+            names: ["*"]
+          privileges: [TRUNCATE]
+      validate:
+        pattern: "data.success == true && data['violation-count'] == 0"
+        message: payments_app must not be able to truncate billing tables.

--- a/operator/src/crd.rs
+++ b/operator/src/crd.rs
@@ -41,10 +41,10 @@ pub struct NetworkAssertionSpec {
     pub disable_redaction: bool,
 }
 
-/// A network assertion rule (http, dns, or tcp check).
+/// A network assertion rule (http, dns, tcp, postgres, or postgres-grants check).
 ///
 /// The `name` field is required. All other rule fields (type, url, host, port,
-/// headers, expected, validate, etc.) are captured in `fields` via serde flatten.
+/// headers, dsn, query, expected, validate, etc.) are captured in `fields` via serde flatten.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Rule {
     /// Name of this rule.

--- a/operator/tests/test_postgres_default_cluster.py
+++ b/operator/tests/test_postgres_default_cluster.py
@@ -20,7 +20,7 @@ def test_postgres_grants_with_installed_operator(netchecks, k8s_namespace, test_
         shell=True,
         check=True,
     )
-    _initialise_postgres(database_namespace)
+    _initialize_postgres(database_namespace)
 
     subprocess.run(
         f"kubectl apply -n {k8s_namespace} -f {postgres_assertion_manifest}",
@@ -53,7 +53,7 @@ def test_postgres_grants_with_installed_operator(netchecks, k8s_namespace, test_
     time.sleep(3.0)
 
 
-def _initialise_postgres(database_namespace):
+def _initialize_postgres(database_namespace):
     sql = """
     do $$
     begin

--- a/operator/tests/test_postgres_default_cluster.py
+++ b/operator/tests/test_postgres_default_cluster.py
@@ -1,0 +1,129 @@
+import json
+import shlex
+import subprocess
+import time
+
+
+def test_postgres_grants_with_installed_operator(netchecks, k8s_namespace, test_file_path):
+    database_namespace = "database"
+    postgres_db_manifest = test_file_path("postgres-db.yaml")
+    postgres_assertion_manifest = test_file_path("postgres-grants.yaml")
+
+    subprocess.run(
+        f"kubectl create namespace {database_namespace} --dry-run=client -o yaml | kubectl apply -f -",
+        shell=True,
+        check=True,
+    )
+    subprocess.run(f"kubectl apply -n {database_namespace} -f {postgres_db_manifest}", shell=True, check=True)
+    subprocess.run(
+        f"kubectl wait Deployment/postgres -n {database_namespace} --for condition=Available --timeout=120s",
+        shell=True,
+        check=True,
+    )
+    _initialise_postgres(database_namespace)
+
+    subprocess.run(
+        f"kubectl apply -n {k8s_namespace} -f {postgres_assertion_manifest}",
+        shell=True,
+        check=True,
+    )
+
+    assertion_name = "postgres-grants-should-work"
+    _wait_for_job(assertion_name, k8s_namespace)
+    _wait_for_policy_report(assertion_name, k8s_namespace)
+
+    summary = _get_policy_report_summary(assertion_name, k8s_namespace)
+    assert summary["pass"] == 2
+    assert "fail" not in summary
+
+    results = _get_policy_report_results(assertion_name, k8s_namespace)
+    categories = {result["category"] for result in results}
+    assert categories == {"postgres", "postgres-grants"}
+
+    for result in results:
+        assert result["result"] == "pass"
+        test_spec = json.loads(result["properties"]["spec"])
+        assert test_spec["dsn"] == "REDACTED"
+
+    subprocess.run(
+        f"kubectl delete -n {k8s_namespace} -f {postgres_assertion_manifest} --timeout=30s",
+        shell=True,
+        check=True,
+    )
+    time.sleep(3.0)
+
+
+def _initialise_postgres(database_namespace):
+    sql = """
+    do $$
+    begin
+      if not exists (select 1 from pg_roles where rolname = 'payments_app') then
+        create role payments_app;
+      end if;
+    end
+    $$;
+    create schema if not exists billing;
+    create table if not exists billing.invoices(id integer);
+    revoke all on schema billing from payments_app;
+    revoke all on table billing.invoices from payments_app;
+    """
+    subprocess.run(
+        f"kubectl exec -n {database_namespace} deployment/postgres -- psql -U netcheck -d netcheck -v ON_ERROR_STOP=1 -c {shlex.quote(sql)}",
+        shell=True,
+        check=True,
+    )
+
+
+def _wait_for_job(assertion_name, k8s_namespace):
+    for i in range(10):
+        jobs_response = subprocess.run(
+            f"kubectl get jobs -n {k8s_namespace}",
+            shell=True,
+            check=True,
+            capture_output=True,
+        )
+        if assertion_name.encode() in jobs_response.stdout:
+            break
+        time.sleep(1.5**i)
+
+    subprocess.run(
+        f"kubectl wait Job/{assertion_name} -n {k8s_namespace} --for condition=complete --timeout=120s",
+        shell=True,
+        check=True,
+    )
+
+
+def _wait_for_policy_report(assertion_name, k8s_namespace):
+    for i in range(10):
+        policy_report_response = subprocess.run(
+            f"kubectl get policyreports -n {k8s_namespace}",
+            shell=True,
+            check=True,
+            capture_output=True,
+        )
+        if assertion_name.encode() in policy_report_response.stdout:
+            break
+        time.sleep(1.5**i)
+    assert assertion_name.encode() in policy_report_response.stdout
+
+
+def _get_policy_report_summary(assertion_name, k8s_namespace):
+    summary_filter = "jsonpath='{.summary}'"
+    policy_report_summary = subprocess.run(
+        f"""kubectl get policyreport/{assertion_name} -n {k8s_namespace} -o {summary_filter}""",
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    return json.loads(policy_report_summary.stdout)
+
+
+def _get_policy_report_results(assertion_name, k8s_namespace):
+    results_filter = "jsonpath='{.results}'"
+    policy_report_results = subprocess.run(
+        f"""kubectl get policyreport/{assertion_name} -n {k8s_namespace} -o {results_filter}""",
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    return json.loads(policy_report_results.stdout)

--- a/operator/tests/testdata/postgres-db.yaml
+++ b/operator/tests/testdata/postgres-db.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  POSTGRES_USER: netcheck
+  POSTGRES_PASSWORD: netcheck
+  POSTGRES_DB: netcheck
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:18
+          ports:
+            - name: postgres
+              containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: postgres-credentials
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "netcheck", "-d", "netcheck"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres

--- a/operator/tests/testdata/postgres-grants.yaml
+++ b/operator/tests/testdata/postgres-grants.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-netcheck-connection
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://netcheck:netcheck@postgres.database.svc.cluster.local:5432/netcheck
+---
+apiVersion: netchecks.io/v1
+kind: NetworkAssertion
+metadata:
+  name: postgres-grants-should-work
+  annotations:
+    description: Assert Postgres SQL and grant checks work in Kubernetes
+spec:
+  context:
+    - name: database
+      secret:
+        name: postgres-netcheck-connection
+  rules:
+    - name: postgres-sql
+      type: postgres
+      dsn: "{{ database.DATABASE_URL }}"
+      query: "select 42 as answer"
+      validate:
+        pattern: "data.success == true && data.rows[0].answer == 42"
+        message: SQL check should return the expected row.
+    - name: postgres-grants
+      type: postgres-grants
+      dsn: "{{ database.DATABASE_URL }}"
+      rules:
+        - name: payments-app-no-truncate
+          mode: deny
+          roles:
+            names: [payments_app]
+          objects:
+            type: table
+            schemas: [billing]
+            names: ["*"]
+          privileges: [TRUNCATE]
+      validate:
+        pattern: "data.success == true && data['violation-count'] == 0"
+        message: payments_app must not be able to truncate billing tables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "rich>=10.11.0,<16.0.0",
     "common-expression-language>=0.5.6",
     "pyyaml>=6.0.2",
+    "psycopg[binary]>=3,<4",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netcheck"
-version = "0.9.0"
+version = "0.10.0"
 description = "Netchecks is a cloud native tool for specifying and regularly checking assertions about network conditions. Use netchecks to proactively verify whether security controls are working as intended, alerting on misconfiguration."
 readme = "README.md"
 authors = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -430,6 +430,48 @@ def test_run_tcp_config(tcp_config_filename):
     assert tcp_fail["status"] == "pass"  # expected: fail + connection refused = pass
 
 
+def test_postgres_cli_verbose(monkeypatch):
+    monkeypatch.setattr(
+        netcheck_runner,
+        "postgres_query_check",
+        lambda **kwargs: {
+            "spec": {"type": "postgres", "dsn": kwargs["dsn"], "query": kwargs["query"]},
+            "data": {"success": True},
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["postgres", "--dsn", "postgres://example/db", "--query", "select 1", "-v"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Postgres" in result.stderr
+    assert "Passed" in result.stderr
+    data = json.loads(result.stdout)
+    assert data["status"] == "pass"
+
+
+def test_postgres_cli_disable_redaction(monkeypatch):
+    monkeypatch.setattr(
+        netcheck_runner,
+        "postgres_query_check",
+        lambda **kwargs: {
+            "spec": {"type": "postgres", "dsn": kwargs["dsn"], "query": kwargs["query"]},
+            "data": {"success": True},
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["postgres", "--dsn", "postgres://user:secret@example/db", "--query", "select 1", "--disable-redaction"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["spec"]["dsn"] == "postgres://user:secret@example/db"
+
+
 def test_postgres_cli_redacts_dsn_by_default(monkeypatch):
     monkeypatch.setattr(
         netcheck_runner,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 from typer.testing import CliRunner
 
+import netcheck.runner as netcheck_runner
 from netcheck.cli import app
 
 runner = CliRunner()
@@ -427,3 +428,61 @@ def test_run_tcp_config(tcp_config_filename):
 
     tcp_fail = data["assertions"][1]["results"][0]
     assert tcp_fail["status"] == "pass"  # expected: fail + connection refused = pass
+
+
+def test_postgres_cli_redacts_dsn_by_default(monkeypatch):
+    monkeypatch.setattr(
+        netcheck_runner,
+        "postgres_query_check",
+        lambda **kwargs: {
+            "spec": {"type": "postgres", "dsn": kwargs["dsn"], "query": kwargs["query"]},
+            "data": {"success": True},
+        },
+    )
+
+    result = runner.invoke(app, ["postgres", "--dsn", "postgres://user:secret@example/db", "--query", "select 1"])
+
+    assert result.exit_code == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["status"] == "pass"
+    assert data["spec"]["dsn"] == "REDACTED"
+
+
+def test_run_config_supports_validate_pattern(monkeypatch):
+    monkeypatch.setattr(
+        netcheck_runner,
+        "postgres_query_check",
+        lambda **kwargs: {
+            "spec": {"type": "postgres", "dsn": kwargs["dsn"], "query": kwargs["query"]},
+            "data": {"success": True, "rows": [{"answer": 42}]},
+        },
+    )
+    test_config = {
+        "assertions": [
+            {
+                "name": "postgres-validate-pattern",
+                "rules": [
+                    {
+                        "name": "answer-is-42",
+                        "type": "postgres",
+                        "dsn": "postgres://example",
+                        "query": "select 42 as answer",
+                        "validate": {"pattern": "data.rows[0].answer == 42"},
+                    }
+                ],
+            }
+        ]
+    }
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        f.write(json.dumps(test_config))
+        test_config_filename = f.name
+
+    result = runner.invoke(app, ["run", "--config", test_config_filename])
+
+    assert result.exit_code == 0, result.stderr
+    data = json.loads(result.stdout)
+    result = data["assertions"][0]["results"][0]
+    assert result["name"] == "answer-is-42"
+    assert result["status"] == "pass"
+    assert result["spec"]["pattern"] == "data.rows[0].answer == 42"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,325 @@
+import os
+from unittest.mock import Mock
+
+import pytest
+
+import netcheck.runner as netcheck_runner
+from netcheck.checks import postgres as postgres_checks
+from netcheck.checks.postgres import postgres_grants_check, postgres_query_check
+from netcheck.runner import check_individual_assertion
+
+
+def test_postgres_query_check_rejects_multiple_statements():
+    result = postgres_query_check("postgres://example", "select 1; select 2")
+
+    assert result["data"]["success"] is False
+    assert result["data"]["exception-type"] == "ValueError"
+    assert "single SQL statement" in result["data"]["exception"]
+
+
+def test_postgres_query_check_rejects_empty_statement():
+    result = postgres_query_check("postgres://example", "  ")
+
+    assert result["data"]["success"] is False
+    assert result["data"]["exception-type"] == "ValueError"
+    assert "query must not be empty" in result["data"]["exception"]
+
+
+def test_postgres_query_check_default_output_with_mocked_connection(monkeypatch):
+    cursor = Mock()
+    cursor.__enter__ = Mock(return_value=cursor)
+    cursor.__exit__ = Mock(return_value=False)
+    cursor.description = [Mock(name="answer")]
+    cursor.description[0].name = "answer"
+    cursor.fetchmany.return_value = [{"answer": 42}]
+    cursor.rowcount = 1
+
+    connection = Mock()
+    connection.__enter__ = Mock(return_value=connection)
+    connection.__exit__ = Mock(return_value=False)
+    connection.cursor.return_value = cursor
+
+    connect = Mock(return_value=connection)
+    monkeypatch.setattr(postgres_checks.psycopg, "connect", connect)
+
+    result = postgres_query_check("postgres://example", "select 42 as answer")
+
+    assert result["spec"]["type"] == "postgres"
+    assert result["data"]["success"] is True
+    assert result["data"]["row-count"] == 1
+    assert result["data"]["rows"] == [{"answer": 42}]
+    assert connection.read_only is True
+    connection.rollback.assert_called_once()
+    connect.assert_called_once_with("postgres://example", connect_timeout=5, row_factory=postgres_checks.dict_row)
+
+
+def test_postgres_grants_deny_rule_reports_effective_privilege_violation(monkeypatch):
+    responses = {
+        "select r.rolname": [{"rolname": "payments_app"}],
+        "select n.nspname as schema_name, c.relname": [
+            {"schema_name": "billing", "relname": "invoices", "identity": "billing.invoices"}
+        ],
+        "select has_table_privilege": [{"allowed": True}],
+    }
+    cursor = _fake_cursor(responses)
+    connection = _fake_connection(cursor)
+    monkeypatch.setattr(postgres_checks.psycopg, "connect", Mock(return_value=connection))
+
+    result = postgres_grants_check(
+        "postgres://example",
+        [
+            {
+                "name": "payments-app-cannot-truncate",
+                "mode": "deny",
+                "roles": {"names": ["payments_app"]},
+                "objects": {"type": "table", "schemas": ["billing"], "names": ["*"]},
+                "privileges": ["TRUNCATE"],
+            }
+        ],
+    )
+
+    assert result["data"]["success"] is True
+    assert result["data"]["violation-count"] == 1
+    assert result["data"]["violations"] == [
+        {
+            "rule": "payments-app-cannot-truncate",
+            "role": "payments_app",
+            "object-type": "table",
+            "schema": "billing",
+            "object": "invoices",
+            "privilege": "TRUNCATE",
+            "expected": "absent",
+        }
+    ]
+
+
+def test_postgres_grants_deny_rule_without_effective_privilege_has_no_violations(monkeypatch):
+    responses = {
+        "select r.rolname": [{"rolname": "payments_app"}],
+        "select n.nspname as schema_name, c.relname": [
+            {"schema_name": "billing", "relname": "invoices", "identity": "billing.invoices"}
+        ],
+        "select has_table_privilege": [{"allowed": False}],
+    }
+    cursor = _fake_cursor(responses)
+    connection = _fake_connection(cursor)
+    monkeypatch.setattr(postgres_checks.psycopg, "connect", Mock(return_value=connection))
+
+    result = postgres_grants_check(
+        "postgres://example",
+        [
+            {
+                "name": "payments-app-cannot-truncate",
+                "mode": "deny",
+                "roles": {"names": ["payments_app"]},
+                "objects": {"type": "table", "schemas": ["billing"], "names": ["*"]},
+                "privileges": ["TRUNCATE"],
+            }
+        ],
+    )
+
+    assert result["data"]["success"] is True
+    assert result["data"]["violation-count"] == 0
+    assert result["data"]["violations"] == []
+
+
+def test_postgres_grants_require_rule_reports_missing_privilege(monkeypatch):
+    responses = {
+        "select r.rolname": [{"rolname": "billing_reader"}],
+        "select nspname from pg_namespace": [{"nspname": "billing"}],
+        "select has_schema_privilege": [{"allowed": False}],
+    }
+    cursor = _fake_cursor(responses)
+    connection = _fake_connection(cursor)
+    monkeypatch.setattr(postgres_checks.psycopg, "connect", Mock(return_value=connection))
+
+    result = postgres_grants_check(
+        "postgres://example",
+        [
+            {
+                "name": "billing-reader-needs-schema-usage",
+                "mode": "require",
+                "roles": {"names": ["billing_reader"]},
+                "objects": {"type": "schema", "names": ["billing"]},
+                "privileges": ["USAGE"],
+            }
+        ],
+    )
+
+    assert result["data"]["success"] is True
+    assert result["data"]["violation-count"] == 1
+    assert result["data"]["violations"][0]["expected"] == "present"
+
+
+def test_postgres_grants_invalid_rule_returns_failed_check(monkeypatch):
+    cursor = _fake_cursor({})
+    connection = _fake_connection(cursor)
+    monkeypatch.setattr(postgres_checks.psycopg, "connect", Mock(return_value=connection))
+
+    result = postgres_grants_check(
+        "postgres://example",
+        [
+            {
+                "name": "invalid-table-privilege",
+                "mode": "deny",
+                "roles": {"names": ["payments_app"]},
+                "objects": {"type": "table", "schemas": ["billing"], "names": ["*"]},
+                "privileges": ["CREATE"],
+            }
+        ],
+    )
+
+    assert result["data"]["success"] is False
+    assert result["data"]["exception-type"] == "ValueError"
+    assert "unsupported table privileges: CREATE" in result["data"]["exception"]
+
+
+def test_runner_redacts_postgres_dsn_and_params(monkeypatch):
+    monkeypatch.setattr(
+        netcheck_runner,
+        "postgres_query_check",
+        lambda **kwargs: {
+            "spec": {"type": "postgres", "dsn": kwargs["dsn"], "params": kwargs["params"]},
+            "data": {"success": True},
+        },
+    )
+
+    result = check_individual_assertion(
+        "postgres",
+        {
+            "type": "postgres",
+            "dsn": "postgres://user:secret@example/db",
+            "query": "select %s",
+            "params": ["secret"],
+        },
+        err_console=Mock(),
+    )
+
+    assert result["status"] == "pass"
+    assert result["spec"]["dsn"] == "REDACTED"
+    assert result["spec"]["params"] == "REDACTED"
+
+
+@pytest.mark.skipif(not os.environ.get("NETCHECK_POSTGRES_DSN"), reason="NETCHECK_POSTGRES_DSN is not set")
+def test_postgres_query_check_with_real_postgres():
+    result = postgres_query_check(os.environ["NETCHECK_POSTGRES_DSN"], "select 42 as answer")
+
+    assert result["data"]["success"] is True, result
+    assert result["data"]["rows"] == [{"answer": 42}]
+
+
+@pytest.mark.skipif(not os.environ.get("NETCHECK_POSTGRES_DSN"), reason="NETCHECK_POSTGRES_DSN is not set")
+def test_postgres_query_check_with_real_postgres_read_only_negative_control():
+    result = postgres_query_check(
+        os.environ["NETCHECK_POSTGRES_DSN"],
+        "create table netcheck_read_only_probe(id integer)",
+    )
+
+    assert result["data"]["success"] is False, result
+    assert result["data"].get("sqlstate") == "25006"
+
+
+@pytest.mark.skipif(not os.environ.get("NETCHECK_POSTGRES_DSN"), reason="NETCHECK_POSTGRES_DSN is not set")
+def test_postgres_grants_check_with_real_postgres():
+    import psycopg
+
+    dsn = os.environ["NETCHECK_POSTGRES_DSN"]
+    with psycopg.connect(dsn, autocommit=True) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute("drop schema if exists netcheck_grants_probe cascade")
+            cursor.execute("drop role if exists netcheck_grants_probe_role")
+            cursor.execute("create role netcheck_grants_probe_role")
+            cursor.execute("create schema netcheck_grants_probe")
+            cursor.execute("create table netcheck_grants_probe.invoices(id integer)")
+            cursor.execute("grant usage on schema netcheck_grants_probe to netcheck_grants_probe_role")
+
+    try:
+        require_result = postgres_grants_check(
+            dsn,
+            [
+                {
+                    "name": "probe-role-has-schema-usage",
+                    "mode": "require",
+                    "roles": {"names": ["netcheck_grants_probe_role"]},
+                    "objects": {"type": "schema", "names": ["netcheck_grants_probe"]},
+                    "privileges": ["USAGE"],
+                }
+            ],
+        )
+        assert require_result["data"]["success"] is True, require_result
+        assert require_result["data"]["violation-count"] == 0
+
+        deny_result = postgres_grants_check(
+            dsn,
+            [
+                {
+                    "name": "probe-role-cannot-truncate",
+                    "mode": "deny",
+                    "roles": {"names": ["netcheck_grants_probe_role"]},
+                    "objects": {"type": "table", "schemas": ["netcheck_grants_probe"], "names": ["*"]},
+                    "privileges": ["TRUNCATE"],
+                }
+            ],
+        )
+        assert deny_result["data"]["success"] is True, deny_result
+        assert deny_result["data"]["violation-count"] == 0
+
+        with psycopg.connect(dsn, autocommit=True) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("grant truncate on table netcheck_grants_probe.invoices to netcheck_grants_probe_role")
+
+        violated_deny_result = postgres_grants_check(
+            dsn,
+            [
+                {
+                    "name": "probe-role-cannot-truncate",
+                    "mode": "deny",
+                    "roles": {"names": ["netcheck_grants_probe_role"]},
+                    "objects": {"type": "table", "schemas": ["netcheck_grants_probe"], "names": ["*"]},
+                    "privileges": ["TRUNCATE"],
+                }
+            ],
+        )
+        assert violated_deny_result["data"]["success"] is True, violated_deny_result
+        assert violated_deny_result["data"]["violation-count"] == 1
+    finally:
+        with psycopg.connect(dsn, autocommit=True) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("drop schema if exists netcheck_grants_probe cascade")
+                cursor.execute("drop role if exists netcheck_grants_probe_role")
+
+
+def _fake_cursor(responses):
+    cursor = Mock()
+    cursor.__enter__ = Mock(return_value=cursor)
+    cursor.__exit__ = Mock(return_value=False)
+    cursor._last_sql = ""
+
+    def execute(sql, params=None):
+        cursor._last_sql = " ".join(sql.split())
+
+    def fetchall():
+        return _response_for_sql(responses, cursor._last_sql)
+
+    def fetchone():
+        return _response_for_sql(responses, cursor._last_sql)[0]
+
+    cursor.execute.side_effect = execute
+    cursor.fetchall.side_effect = fetchall
+    cursor.fetchone.side_effect = fetchone
+    return cursor
+
+
+def _fake_connection(cursor):
+    connection = Mock()
+    connection.__enter__ = Mock(return_value=connection)
+    connection.__exit__ = Mock(return_value=False)
+    connection.cursor.return_value = cursor
+    return connection
+
+
+def _response_for_sql(responses, sql):
+    for prefix, response in responses.items():
+        if sql.startswith(prefix):
+            return response
+    return [{"set_config": "5s"}]

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -10,19 +10,19 @@ from netcheck.runner import check_individual_assertion
 
 
 def test_postgres_query_check_rejects_multiple_statements():
+    # psycopg3 raises ProgrammingError for multi-statement strings; the probe
+    # surfaces this as success=False so the validation rule can catch it.
     result = postgres_query_check("postgres://example", "select 1; select 2")
 
     assert result["data"]["success"] is False
-    assert result["data"]["exception-type"] == "ValueError"
-    assert "single SQL statement" in result["data"]["exception"]
+    assert "exception-type" in result["data"]
 
 
 def test_postgres_query_check_rejects_empty_statement():
     result = postgres_query_check("postgres://example", "  ")
 
     assert result["data"]["success"] is False
-    assert result["data"]["exception-type"] == "ValueError"
-    assert "query must not be empty" in result["data"]["exception"]
+    assert "exception-type" in result["data"]
 
 
 def test_postgres_query_check_default_output_with_mocked_connection(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -376,6 +376,7 @@ source = { editable = "." }
 dependencies = [
     { name = "common-expression-language" },
     { name = "dnspython" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -395,6 +396,7 @@ dev = [
 requires-dist = [
     { name = "common-expression-language", specifier = ">=0.5.6" },
     { name = "dnspython", specifier = ">=2.2,<3.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3,<4" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.28,<3.0" },
@@ -438,6 +440,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431 },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001 },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813 },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799 },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050 },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428 },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746 },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033 },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175 },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203 },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509 },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551 },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054 },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122 },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943 },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697 },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995 },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180 },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828 },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757 },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546 },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197 },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627 },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782 },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377 },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023 },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423 },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137 },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671 },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601 },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513 },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243 },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347 },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393 },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592 },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292 },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023 },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985 },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745 },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486 },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427 },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549 },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256 },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204 },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811 },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849 },
 ]
 
 [[package]]
@@ -793,6 +864,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add generic PostgreSQL SQL checks and higher-level effective grant checks.
- Add docs, CLI support, redaction, and Kubernetes examples for PostgreSQL access validation.
- Add unit tests, PostgreSQL 18 integration coverage, CI service tests, and a Kind operator test.

## Validation
- uv run ruff check .
- uv run pytest tests --cov netcheck --cov-report=term
- NETCHECK_POSTGRES_DSN=postgresql://netcheck:netcheck@localhost:55432/netcheck uv run pytest tests/test_postgres.py -v against local postgres:18
- npm run build in docs
- NETCHECKS_IMAGE_TAG=pg-local uv run pytest operator/tests/test_postgres_default_cluster.py -v -s against local Kind cluster