### PR TITLE
Fix release metadata and Helm setup action

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -21,7 +21,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
       - name: Run chart-releaser
         uses: hardbyte/chart-releaser-action@main
         with:

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "netcheck"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "common-expression-language" },


### PR DESCRIPTION
## Summary
- Update the editable `netcheck` package version in `uv.lock` to match `pyproject.toml` after the v0.10.0 release.
- Update the Helm chart release workflow from `azure/setup-helm@v3` to `azure/setup-helm@v5`, consolidating Dependabot PR #324.

## Validation
- `uv run pytest tests/test_postgres.py -q`
- `uv run ruff check netcheck/checks/postgres.py tests/test_postgres.py`