### PR TITLE
ci: pin coveralls action to v2 for current runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           uv run pytest tests --cov netcheck --cov-report=lcov --cov-report=term
         timeout-minutes: 10
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: Unittests-${{ matrix.os }}-${{ matrix.python-version }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true


### PR DESCRIPTION
Updating action `coverallsapp/github-action@master` resolves to a **node16** JavaScript action. `@v2` is a composite action wrapping the coveralls CLI (no Node runtime to deprecate), and pinning it also stops tracking a floating `master` branch. All inputs used in `ci.yaml` (`github-token`, `path-to-lcov`, `flag-name`, `parallel`, `parallel-finished`) are supported in v2 — `path-to-lcov` is retained for backward compatibility.

Verified as composite/docker/node24 and left alone: `chartboost/ruff-action@v1`, `reviewdog/action-shellcheck@v1`, `helm/kind-action@v1` (node24), `helm/chart-testing-action@v2.8.0`, `hardbyte/chart-releaser-action@main`, `hadolint-action`, `crate-ci/typos`, `pypa/gh-action-pypi-publish` (docker), `Swatinem/rust-cache@v2`.